### PR TITLE
Added hardforkActivationHeights configuration for RSKJ

### DIFF
--- a/rsknode/node.conf
+++ b/rsknode/node.conf
@@ -60,3 +60,19 @@ rpc {
     }
   ]
 }
+
+blockchain.config {
+    name = regtest
+    hardforkActivationHeights = {
+        bahamas = 10,
+        afterBridgeSync = -1,
+        orchid = 10,
+        orchid060 = 10,
+        wasabi100 = 10,
+        twoToThree = 10,
+        papyrus200 = 10
+    },
+    consensusRules = {
+        rskip97 = -1 # disable orchid difficulty drop
+    }
+}

--- a/rsknode/rskj.sh
+++ b/rsknode/rskj.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -e
-
 ROOTDIR=`dirname $0`
 ROOTDIR=`readlink -f $ROOTDIR`
 REPO="https://github.com/rsksmart/rskj.git"
@@ -36,4 +35,4 @@ java -Drsk.conf.file=./node.conf -Dlogback.configurationFile=./log.conf.xml \
 	-Ddatabase.dir=./db \
 	-Drpc.providers.web.http.hosts.0=localhost \
 	-Drpc.providers.web.http.hosts.1=$LOCALIP \
-	-jar $JARPATH/$JAR co.rsk.Start --regtest
+	-jar "$JARPATH/$JAR" co.rsk.Start --regtest


### PR DESCRIPTION
Modified node.conf file to avoid the following error with the genesis block: java.lang.IllegalArgumentException: A block header must have 16/17 elements or 19/20 including merged-mining fields but it had 19