### PR TITLE
Modifications to avoid signing typed data with the RSKJ node in tests

### DIFF
--- a/src/relayclient/AccountManager.ts
+++ b/src/relayclient/AccountManager.ts
@@ -26,11 +26,13 @@ export default class AccountManager {
   private readonly accounts: AccountKeypair[] = []
   private readonly config: GSNConfig
   readonly chainId: number
+  private readonly signWithProviderImpl: (signedData: any) => Promise<string>
 
-  constructor (provider: HttpProvider, chainId: number, config: GSNConfig) {
+  constructor (provider: HttpProvider, chainId: number, config: GSNConfig, signWithProviderImpl?: (signedData: any) => Promise<string>) {
     this.web3 = new Web3(provider)
     this.chainId = chainId
     this.config = config
+    this.signWithProviderImpl = signWithProviderImpl ?? this._signWithProviderDefault
   }
 
   addAccount (keypair: AccountKeypair): void {
@@ -103,6 +105,10 @@ export default class AccountManager {
   // a) allow different implementations in the future, and
   // b) allow spying on Account Manager in tests
   async _signWithProvider (signedData: any): Promise<string> {
+    return await this.signWithProviderImpl(signedData)
+  }
+
+  async _signWithProviderDefault (signedData: any): Promise<string> {
     return await getEip712Signature(
       this.web3,
       signedData,

--- a/src/relayclient/RelayProvider.ts
+++ b/src/relayclient/RelayProvider.ts
@@ -300,12 +300,32 @@ export class RelayProvider implements HttpProvider {
   // The RSKJ node doesn't support additional parameters in RPC calls.
   // When using the original provider with the RSKJ node it is necessary to remove the additional useGSN property.
   _getPayloadForRSKProvider (payload: JsonRpcPayload): JsonRpcPayload {
-    let p = payload
+    let p: JsonRpcPayload = payload
+
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    if (payload.params[0]?.hasOwnProperty('useGSN')) {
+    if (payload.params[0]?.hasOwnProperty('useGSN') || payload.params[0]?.hasOwnProperty('paymaster')) {
       // Deep copy the payload to safely remove the useGSN property
       p = JSON.parse(JSON.stringify(payload))
-      delete p.params[0].useGSN
+
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (payload.params[0]?.hasOwnProperty('useGSN')) {
+        delete p.params[0].useGSN
+      }
+
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (payload.params[0]?.hasOwnProperty('paymaster')) {
+        delete p.params[0].paymaster
+      }
+
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (payload.params[0]?.hasOwnProperty('forceGasPrice')) {
+        delete p.params[0].forceGasPrice
+      }
+
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (payload.params[0]?.hasOwnProperty('factory')) {
+        delete p.params[0].factory
+      }
     }
 
     return p

--- a/test/ProxyFactory.test.ts
+++ b/test/ProxyFactory.test.ts
@@ -10,7 +10,7 @@ import { expectRevert, expectEvent } from '@openzeppelin/test-helpers'
 import { toChecksumAddress } from 'web3-utils'
 import { ethers } from 'ethers'
 import chai from 'chai'
-import { getTestingEnvironment } from './TestUtils'
+import { addr, bytes32, getTestingEnvironment, stripHex } from './TestUtils'
 import { Environment } from '../src/common/Environments'
 import { EIP712DomainType, ForwardRequestType } from '../src/common/EIP712/TypedRequestData'
 import { constants } from '../src/common/Constants'
@@ -20,18 +20,6 @@ const keccak256 = web3.utils.keccak256
 const SmartWallet = artifacts.require('SmartWallet')
 const TestToken = artifacts.require('TestToken')
 const ProxyFactory = artifacts.require('ProxyFactory')
-
-function addr (n: number): string {
-  return '0x' + n.toString().repeat(40)
-}
-
-function bytes32 (n: number): string {
-  return '0x' + n.toString().repeat(64).slice(0, 64)
-}
-
-function stripHex (s: string): string {
-  return s.slice(2, s.length)
-}
 
 contract('ProxyFactory', ([from]) => {
   let fwd: SmartWalletInstance

--- a/test/relayclient/KnownRelaysManager.test.ts
+++ b/test/relayclient/KnownRelaysManager.test.ts
@@ -11,7 +11,7 @@ import {
   TestRecipientInstance,
   SmartWalletInstance, ProxyFactoryInstance
 } from '../../types/truffle-contracts'
-import { deployHub, evmMineMany, startRelay, stopRelay, getTestingEnvironment, createProxyFactory, createSmartWallet } from '../TestUtils'
+import { deployHub, evmMineMany, startRelay, stopRelay, getTestingEnvironment, createProxyFactory, createSmartWallet, getGaslessAccount } from '../TestUtils'
 import { prepareTransaction } from './RelayProvider.test'
 import sinon from 'sinon'
 import { ChildProcessWithoutNullStreams } from 'child_process'
@@ -46,8 +46,7 @@ contract('KnownRelaysManager', function (
     notActiveRelay,
     workerPaymasterRejected,
     workerTransactionRelayed,
-    owner,
-    other
+    owner
   ]) {
   const relayLookupWindowBlocks = 100
 
@@ -99,6 +98,8 @@ contract('KnownRelaysManager', function (
       await stake(stakeManager, relayHub, activePaymasterRejected, owner)
       await stake(stakeManager, relayHub, activeTransactionRelayed, owner)
       await stake(stakeManager, relayHub, notActiveRelay, owner)
+
+      const other = await getGaslessAccount()
       const nextNonce = (await smartWallet.getNonce()).toString()
       const txPaymasterRejected = await prepareTransaction(testRecipient, other, workerPaymasterRejected, paymaster.address, web3, nextNonce, smartWallet.address)
       const txTransactionRelayed = await prepareTransaction(testRecipient, other, workerTransactionRelayed, paymaster.address, web3, nextNonce, smartWallet.address)

--- a/test/smartwallet/SmartWallet.test.ts
+++ b/test/smartwallet/SmartWallet.test.ts
@@ -12,7 +12,7 @@ import { BN, bufferToHex, privateToAddress, toBuffer } from 'ethereumjs-util'
 import { ether, expectRevert } from '@openzeppelin/test-helpers'
 import { toChecksumAddress } from 'web3-utils'
 import { isRsk, Environment } from '../../src/common/Environments'
-import { getTestingEnvironment, createProxyFactory, createSmartWallet } from '../TestUtils'
+import { getTestingEnvironment, createProxyFactory, createSmartWallet, bytes32, addr } from '../TestUtils'
 import { EIP712DomainType, ForwardRequestType, ENVELOPING_PARAMS } from '../../src/common/EIP712/TypedRequestData'
 
 require('source-map-support').install({ errorFormatterForce: true })
@@ -24,14 +24,6 @@ const SmartWallet = artifacts.require('SmartWallet')
 const TestSmartWallet = artifacts.require('TestSmartWallet')
 
 const keccak256 = web3.utils.keccak256
-
-function addr (n: number): string {
-  return '0x' + n.toString().repeat(40)
-}
-
-function bytes32 (n: number): string {
-  return '0x' + n.toString().repeat(64).slice(0, 64)
-}
 
 contract('SmartWallet', ([from]) => {
   const countParams = ForwardRequestType.length


### PR DESCRIPTION
Tests were modified to use local signTypedData implementation instead of relying on the RSKJ node.
Moved utility functions for generating gasless addresses to TestUtils.