### PR TITLE
soliditySha3Raw used

### DIFF
--- a/contracts/factory/ProxyFactory.sol
+++ b/contracts/factory/ProxyFactory.sol
@@ -121,8 +121,7 @@ contract ProxyFactory is IProxyFactory {
         bytes32 digest = keccak256(packed);
         require(digest.recover(sig) == owner, string(packed));
 
-        bytes32 initParamsHash = (initParams.length == 0 ? bytes32(0) : keccak256(initParams));
-        bytes32 salt = keccak256(abi.encodePacked(owner, recoverer, logic, initParamsHash, index));
+        bytes32 salt = keccak256(abi.encodePacked(owner, recoverer, logic, keccak256(initParams), index));
 
         //772d909b  =>  initialize(address owner,address logic,address tokenAddr,bytes initParams,bytes transferData)  
         bytes memory initData = abi.encodeWithSelector(
@@ -148,8 +147,7 @@ contract ProxyFactory is IProxyFactory {
         _verifySig(req, domainSeparator, requestTypeHash, suffixData, sig);
         _updateNonce(req);
 
-        bytes32 initParamsHash = (req.data.length == 0 ? bytes32(0) : keccak256(req.data));
-        bytes32 salt = keccak256(abi.encodePacked(req.from, req.recoverer, req.to, initParamsHash, req.index));
+        bytes32 salt = keccak256(abi.encodePacked(req.from, req.recoverer, req.to, keccak256(req.data), req.index));
 
         //772d909b  =>  initialize(address owner,address logic,address tokenAddr,bytes initParams,bytes transferData)  
         //a9059cbb = transfer(address _to, uint256 _value) public returns (bool success)

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -13,5 +13,6 @@ export const constants = {
   ZERO_BYTES32: '0x0000000000000000000000000000000000000000000000000000000000000000',
   MAX_UINT256: new BN('2').pow(new BN('256')).sub(new BN('1')),
   MAX_INT256: new BN('2').pow(new BN('255')).sub(new BN('1')),
-  MIN_INT256: new BN('2').pow(new BN('255')).mul(new BN('-1'))
+  MIN_INT256: new BN('2').pow(new BN('255')).mul(new BN('-1')),
+  SHA3_NULL_S: '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
 }

--- a/src/relayclient/RelayProvider.ts
+++ b/src/relayclient/RelayProvider.ts
@@ -157,7 +157,7 @@ export class RelayProvider implements HttpProvider {
       { t: 'address', v: ownerEOA },
       { t: 'address', v: recoverer },
       { t: 'address', v: customLogic },
-      { t: 'bytes32', v: logicInitParamsHash ?? constants.ZERO_BYTES32 },
+      { t: 'bytes32', v: logicInitParamsHash ?? constants.SHA3_NULL_S },
       { t: 'uint256', v: walletIndex }
     ) ?? ''
 

--- a/test/ProxyFactory.test.ts
+++ b/test/ProxyFactory.test.ts
@@ -7,7 +7,7 @@ import {
 import { EIP712TypedData, signTypedData_v4, TypedDataUtils } from 'eth-sig-util'
 import { bufferToHex, privateToAddress, toBuffer } from 'ethereumjs-util'
 import { expectRevert, expectEvent } from '@openzeppelin/test-helpers'
-import { toChecksumAddress } from 'web3-utils'
+import { toChecksumAddress, soliditySha3Raw } from 'web3-utils'
 import { ethers } from 'ethers'
 import chai from 'chai'
 import { addr, bytes32, getTestingEnvironment, stripHex } from './TestUtils'
@@ -60,7 +60,7 @@ contract('ProxyFactory', ([from]) => {
   describe('#getSmartWalletAddress', () => {
     it('should create the correct create2 Address', async () => {
       const logicAddress = addr(0)
-      const initParamsHash = constants.ZERO_BYTES32
+      const initParamsHash = constants.SHA3_NULL_S
       const recoverer = addr(0)
       const index = '0'
       const create2Address = await factory.getSmartWalletAddress(ownerAddress, recoverer, logicAddress, initParamsHash, index)
@@ -115,13 +115,13 @@ contract('ProxyFactory', ([from]) => {
         index, initParams, signatureCollapsed)
 
       const expectedAddress = await factory.getSmartWalletAddress(ownerAddress, recoverer,
-        logicAddress, keccak256(initParams) ?? constants.ZERO_BYTES32, index)
+        logicAddress, soliditySha3Raw({ t: 'bytes', v: initParams }), index)
 
       const salt = web3.utils.soliditySha3(
         { t: 'address', v: ownerAddress },
         { t: 'address', v: recoverer },
         { t: 'address', v: logicAddress },
-        { t: 'bytes32', v: keccak256(initParams) ?? constants.ZERO_BYTES32 },
+        { t: 'bytes32', v: soliditySha3Raw({ t: 'bytes', v: initParams }) },
         { t: 'uint256', v: index }
       ) ?? ''
 
@@ -140,7 +140,7 @@ contract('ProxyFactory', ([from]) => {
       const index = '0'
 
       const expectedAddress = await factory.getSmartWalletAddress(ownerAddress, recoverer,
-        logicAddress, keccak256(initParams) ?? constants.ZERO_BYTES32, index)
+        logicAddress, soliditySha3Raw({ t: 'bytes', v: initParams }), index)
 
       const toSign: string = web3.utils.soliditySha3(
         { t: 'bytes2', v: '0x1910' },
@@ -201,7 +201,7 @@ contract('ProxyFactory', ([from]) => {
       const index = '0'
 
       const expectedAddress = await factory.getSmartWalletAddress(ownerAddress, recoverer,
-        logicAddress, keccak256(initParams) ?? constants.ZERO_BYTES32, index)
+        logicAddress, soliditySha3Raw({ t: 'bytes', v: initParams }), index)
 
       const toSign: string = web3.utils.soliditySha3(
         { t: 'bytes2', v: '0x1910' },
@@ -224,7 +224,7 @@ contract('ProxyFactory', ([from]) => {
         { t: 'address', v: ownerAddress },
         { t: 'address', v: recoverer },
         { t: 'address', v: logicAddress },
-        { t: 'bytes32', v: keccak256(initParams) ?? constants.ZERO_BYTES32 },
+        { t: 'bytes32', v: soliditySha3Raw({ t: 'bytes', v: initParams }) },
         { t: 'uint256', v: index }
       ) ?? ''
 
@@ -315,7 +315,7 @@ contract('ProxyFactory', ([from]) => {
       const index = '0'
 
       const expectedAddress = await factory.getSmartWalletAddress(ownerAddress, recoverer,
-        logicAddress, keccak256(initParams) ?? constants.ZERO_BYTES32, index)
+        logicAddress, soliditySha3Raw({ t: 'bytes', v: initParams }), index)
 
       token = await TestToken.new()
       await token.mint('200', expectedAddress)
@@ -363,7 +363,7 @@ contract('ProxyFactory', ([from]) => {
         { t: 'address', v: ownerAddress },
         { t: 'address', v: recoverer },
         { t: 'address', v: logicAddress },
-        { t: 'bytes32', v: keccak256(initParams) ?? constants.ZERO_BYTES32 },
+        { t: 'bytes32', v: soliditySha3Raw({ t: 'bytes', v: initParams }) },
         { t: 'uint256', v: index }
       ) ?? ''
 
@@ -389,7 +389,7 @@ contract('ProxyFactory', ([from]) => {
       const index = '0'
 
       const expectedAddress = await factory.getSmartWalletAddress(ownerAddress, recoverer,
-        logicAddress, keccak256(initParams) ?? constants.ZERO_BYTES32, index)
+        logicAddress, soliditySha3Raw({ t: 'bytes', v: initParams }), index)
 
       token = await TestToken.new()
       await token.mint('200', expectedAddress)
@@ -449,7 +449,7 @@ contract('ProxyFactory', ([from]) => {
       const index = '0'
 
       const expectedAddress = await factory.getSmartWalletAddress(ownerAddress, recoverer,
-        logicAddress, keccak256(initParams) ?? constants.ZERO_BYTES32, index)
+        logicAddress, soliditySha3Raw({ t: 'bytes', v: initParams }), index)
 
       const originalBalance = await token.balanceOf(expectedAddress)
       const typeName = `ForwardRequest(${FORWARDER_PARAMS})`
@@ -504,7 +504,7 @@ contract('ProxyFactory', ([from]) => {
       const index = '0'
 
       const expectedAddress = await factory.getSmartWalletAddress(ownerAddress, recoverer,
-        logicAddress, keccak256(initParams) ?? constants.ZERO_BYTES32, index)
+        logicAddress, soliditySha3Raw({ t: 'bytes', v: initParams }), index)
 
       token = await TestToken.new()
       await token.mint('200', expectedAddress)
@@ -552,7 +552,7 @@ contract('ProxyFactory', ([from]) => {
         { t: 'address', v: ownerAddress },
         { t: 'address', v: recoverer },
         { t: 'address', v: logicAddress },
-        { t: 'bytes32', v: keccak256(initParams) ?? constants.ZERO_BYTES32 },
+        { t: 'bytes32', v: soliditySha3Raw({ t: 'bytes', v: initParams }) },
         { t: 'uint256', v: index }
       ) ?? ''
 

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -14,6 +14,7 @@ import { PrefixedHexString } from 'ethereumjs-tx'
 import { sleep, getEip712Signature } from '../src/common/Utils'
 import { RelayHubConfiguration } from '../src/relayclient/types/RelayHubConfiguration'
 import EnvelopingTypedRequestData, { GsnRequestType, getDomainSeparatorHash, ENVELOPING_PARAMS, GsnDomainSeparatorType, EIP712DomainType, ForwardRequestType } from '../src/common/EIP712/TypedRequestData'
+import { soliditySha3Raw } from 'web3-utils'
 
 // @ts-ignore
 import { TypedDataUtils, signTypedData_v4 } from 'eth-sig-util'
@@ -356,7 +357,7 @@ export async function createSmartWallet (ownerEOA: string, factory: ProxyFactory
     await factory.relayedUserSmartWalletCreation(rReq, getDomainSeparatorHash(factory.address, chainId), typeHash, '0x', deploySignature)
   }
 
-  const swAddress = await factory.getSmartWalletAddress(ownerEOA, constants.ZERO_ADDRESS, logicAddr, web3.utils.keccak256(initParams) ?? constants.ZERO_BYTES32, '0')
+  const swAddress = await factory.getSmartWalletAddress(ownerEOA, constants.ZERO_ADDRESS, logicAddr, soliditySha3Raw({ t: 'bytes', v: initParams }), '0')
 
   const SmartWallet = artifacts.require('SmartWallet')
   const sw: SmartWalletInstance = await SmartWallet.at(swAddress)

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -36,8 +36,8 @@ import { Server } from 'http'
 import HttpClient from '../../src/relayclient/HttpClient'
 import HttpWrapper from '../../src/relayclient/HttpWrapper'
 import { RelayTransactionRequest } from '../../src/relayclient/types/RelayTransactionRequest'
-import { constants } from '../../src/common/Constants'
 import { AccountKeypair } from '../../src/relayclient/AccountManager'
+import { soliditySha3Raw } from 'web3-utils'
 
 const StakeManager = artifacts.require('StakeManager')
 const TestRecipient = artifacts.require('TestRecipient')
@@ -310,7 +310,7 @@ contract('RelayClient', function (accounts) {
         useGSN: true
       }
 
-      const swAddress = await factory.getSmartWalletAddress(eoaWithoutSmartWalletAccount.address, addr(0), details.to, web3.utils.keccak256(details.data) ?? constants.ZERO_BYTES32, '0')
+      const swAddress = await factory.getSmartWalletAddress(eoaWithoutSmartWalletAccount.address, addr(0), details.to, soliditySha3Raw({ t: 'bytes', v: details.data }), '0')
       await token.mint('1000', swAddress)
 
       const estimatedGasResult = await relayClient.calculateSmartWalletDeployGas(details)
@@ -342,7 +342,7 @@ contract('RelayClient', function (accounts) {
         index: '0'
       }
 
-      const swAddress = await factory.getSmartWalletAddress(eoaWithoutSmartWalletAccount.address, addr(0), deployOptions.to, web3.utils.keccak256(deployOptions.data) ?? constants.ZERO_BYTES32, '0')
+      const swAddress = await factory.getSmartWalletAddress(eoaWithoutSmartWalletAccount.address, addr(0), deployOptions.to, soliditySha3Raw({ t: 'bytes', v: deployOptions.data }), '0')
       await token.mint('1000', swAddress)
 
       assert.equal(await web3.eth.getCode(swAddress), '0x00', 'SmartWallet not yet deployed, it must not have installed code')
@@ -370,7 +370,7 @@ contract('RelayClient', function (accounts) {
         { t: 'address', v: eoaWithoutSmartWalletAccount.address },
         { t: 'address', v: addr(0) },
         { t: 'address', v: deployOptions.to },
-        { t: 'bytes32', v: web3.utils.keccak256(deployOptions.data) ?? constants.ZERO_BYTES32 },
+        { t: 'bytes32', v: soliditySha3Raw({ t: 'bytes', v: deployOptions.data }) },
         { t: 'uint256', v: '0' }
       ) ?? ''
 

--- a/test/relayclient/RelayProvider.test.ts
+++ b/test/relayclient/RelayProvider.test.ts
@@ -255,7 +255,7 @@ contract('RelayProvider', function (accounts) {
       const rProvider = new RelayProvider(underlyingProvider, gsnConfig)
       const swAddress = rProvider.calculateSmartWalletAddress(factory.address, gaslessAccount.address, recoverer, customLogic, walletIndex, bytecodeHash)
 
-      const expectedAddress = await factory.getSmartWalletAddress(gaslessAccount.address, recoverer, customLogic, constants.ZERO_BYTES32, walletIndex)
+      const expectedAddress = await factory.getSmartWalletAddress(gaslessAccount.address, recoverer, customLogic, constants.SHA3_NULL_S, walletIndex)
 
       assert.equal(swAddress, expectedAddress)
     }


### PR DESCRIPTION
soliditySha3Raw used for calculating the hash of variable bytes params that need to be sent as a hash (bytes32) to a solidity contract, in order to avoid having to manually put the hash of empty bytes if the keccak256 is null