### PR TITLE
Avoid signing typed data with RSKJ and use latest RSKJ version (PAPYRUS 2.1.0)

### DIFF
--- a/contracts/BaseRelayRecipient.sol
+++ b/contracts/BaseRelayRecipient.sol
@@ -10,6 +10,6 @@ contract BaseRelayRecipient {
 
 
       function versionPaymaster() external view virtual returns (string memory){
-        return "2.0.0+opengsn.test-pea.baselerayrecipient";
+        return "2.0.1+opengsn.test-pea.baselerayrecipient";
     }
 }

--- a/contracts/test/TestEnvelopingPaymaster.sol
+++ b/contracts/test/TestEnvelopingPaymaster.sol
@@ -7,7 +7,7 @@ import "../paymaster/BasePaymaster.sol";
 contract TestEnvelopingPaymaster is BasePaymaster {
 
     function versionPaymaster() external view override virtual returns (string memory){
-        return "2.0.0+opengsn.test-pea.ipaymaster";
+        return "2.0.1+opengsn.test-pea.ipaymaster";
     }
 
     event SampleRecipientPreCall();

--- a/contracts/test/TestPaymasterEverythingAccepted.sol
+++ b/contracts/test/TestPaymasterEverythingAccepted.sol
@@ -7,7 +7,7 @@ import "../paymaster/BasePaymaster.sol";
 contract TestPaymasterEverythingAccepted is BasePaymaster {
 
     function versionPaymaster() external view override virtual returns (string memory){
-        return "2.0.0+opengsn.test-pea.ipaymaster";
+        return "2.0.1+opengsn.test-pea.ipaymaster";
     }
 
     event SampleRecipientPreCall();

--- a/contracts/test/TestPaymasterVariableGasLimits.sol
+++ b/contracts/test/TestPaymasterVariableGasLimits.sol
@@ -6,7 +6,7 @@ import "./TestPaymasterEverythingAccepted.sol";
 
 contract TestPaymasterVariableGasLimits is TestPaymasterEverythingAccepted {
 
-    string public override versionPaymaster = "2.0.0+opengsn.test-vgl.ipaymaster";
+    string public override versionPaymaster = "2.0.1+opengsn.test-vgl.ipaymaster";
 
     event SampleRecipientPreCallWithValues(
         uint256 gasleft,

--- a/contracts/test/TestRecipient.sol
+++ b/contracts/test/TestRecipient.sol
@@ -8,7 +8,7 @@ import "./TestPaymasterConfigurableMisbehavior.sol";
 
 contract TestRecipient {
 
-    string public versionRecipient = "2.0.0+opengsn.test.irelayrecipient";
+    string public versionRecipient = "2.0.1+opengsn.test.irelayrecipient";
 
 
     event Reverting(string message);

--- a/rsknode/rskj.sh
+++ b/rsknode/rskj.sh
@@ -4,16 +4,14 @@ ROOTDIR=`dirname $0`
 ROOTDIR=`readlink -f $ROOTDIR`
 REPO="https://github.com/rsksmart/rskj.git"
 SRCDIR="`pwd`/src"
-TAG="PAPYRUS-2.0.1"
-#Using a branch from Papyrus with eth_signTypedData and rpc revert reason for testing
-BRANCH="rpc-revert-reason"
+TAG="PAPYRUS-2.1.0"
 
 cd $ROOTDIR
 
 if [ ! -d "$SRCDIR" ]; then
 	git clone $REPO $SRCDIR
 	cd $SRCDIR
-	git checkout $BRANCH
+	git checkout $TAG
 	./configure.sh
 	mkdir -p ~/.gradle
 	export GRADLE_USER_HOME=`readlink -f ~/.gradle`

--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -12,6 +12,8 @@ import { ServerConfigParams } from '../relayserver/ServerConfigParams'
 import TypedRequestData from './EIP712/TypedRequestData'
 import chalk from 'chalk'
 
+import sigUtil from 'eth-sig-util'
+
 export function removeHexPrefix (hex: string): string {
   if (hex == null || typeof hex.replace !== 'function') {
     throw new Error('Cannot remove hex prefix')
@@ -60,6 +62,22 @@ export function decodeRevertReason (revertBytes: PrefixedHexString, throwOnError
   }
   // @ts-ignore
   return abi.decodeParameter('string', '0x' + revertBytes.slice(10)) as any
+}
+
+export function getLocalEip712Signature (
+  typedRequestData: TypedRequestData,
+  privateKey: Buffer,
+  jsonStringifyRequest = false
+): PrefixedHexString {
+  let dataToSign: TypedRequestData | string
+  if (jsonStringifyRequest) {
+    dataToSign = JSON.stringify(typedRequestData)
+  } else {
+    dataToSign = typedRequestData
+  }
+
+  // @ts-ignore
+  return sigUtil.signTypedData_v4(privateKey, { data: dataToSign })
 }
 
 export async function getEip712Signature (

--- a/test/Flows.test.ts
+++ b/test/Flows.test.ts
@@ -16,7 +16,7 @@ import {
 import { deployHub, startRelay, stopRelay, getTestingEnvironment, createProxyFactory, createSmartWallet, getExistingGaslessAccount } from './TestUtils'
 import { ChildProcessWithoutNullStreams } from 'child_process'
 import { GSNConfig } from '../src/relayclient/GSNConfigurator'
-import { toBuffer } from 'ethereumjs-util'
+import { toBuffer, bufferToHex } from 'ethereumjs-util'
 import { AccountKeypair } from '../src/relayclient/AccountManager'
 
 const TestRecipient = artifacts.require('tests/TestRecipient')
@@ -100,7 +100,7 @@ options.forEach(params => {
         const env = await getTestingEnvironment()
         const sWalletTemplate: SmartWalletInstance = await SmartWallet.new()
         const factory: ProxyFactoryInstance = await createProxyFactory(sWalletTemplate)
-        const smartWalletInstance: SmartWalletInstance = await createSmartWallet(gaslessAccount.address, factory, env.chainId, '0x' + gaslessAccount.privateKey.toString('hex'))
+        const smartWalletInstance: SmartWalletInstance = await createSmartWallet(gaslessAccount.address, factory, env.chainId, bufferToHex(gaslessAccount.privateKey))
 
         relayClientConfig = {
           logLevel: 5,

--- a/test/SampleRecipient.test.ts
+++ b/test/SampleRecipient.test.ts
@@ -5,7 +5,9 @@ import {
   ProxyFactoryInstance
 } from '../types/truffle-contracts'
 import BN from 'bn.js'
-import { deployHub, createProxyFactory, createSmartWallet, getTestingEnvironment } from './TestUtils'
+import { deployHub, createProxyFactory, createSmartWallet, getTestingEnvironment, getGaslessAccount } from './TestUtils'
+import { AccountKeypair } from '../src/relayclient/AccountManager'
+import { bufferToHex } from 'ethereumjs-util'
 
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
@@ -18,13 +20,15 @@ contract('SampleRecipient', function (accounts) {
   const message = 'hello world'
   let sample: TestRecipientInstance
   let paymaster: TestPaymasterEverythingAcceptedInstance
+  let gaslessAccount: AccountKeypair
 
   before(async function () {
+    gaslessAccount = getGaslessAccount()
     const env = await getTestingEnvironment()
     const chainId = env.chainId
     const sWalletTemplate: SmartWalletInstance = await SmartWallet.new()
     const factory: ProxyFactoryInstance = await createProxyFactory(sWalletTemplate)
-    await createSmartWallet(expectedRealSender, factory, chainId)
+    await createSmartWallet(gaslessAccount.address, factory, chainId, bufferToHex(gaslessAccount.privateKey))
 
     sample = await TestRecipient.new()
     paymaster = await TestPaymasterEverythingAccepted.new()

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -413,6 +413,10 @@ export function stripHex (s: string): string {
   return s.slice(2, s.length)
 }
 
+export function bufferToHexString (b: Buffer): string {
+  return '0x' + b.toString('hex')
+}
+
 /**
  * Not all "signatures" are valid, so using a hard-coded one for predictable error message.
  */

--- a/test/relayclient/KnownRelaysManager.test.ts
+++ b/test/relayclient/KnownRelaysManager.test.ts
@@ -18,6 +18,8 @@ import { ChildProcessWithoutNullStreams } from 'child_process'
 import { RelayRegisteredEventInfo } from '../../src/relayclient/types/RelayRegisteredEventInfo'
 import { Environment } from '../../src/common/Environments'
 import { constants } from '../../src/common/Constants'
+import { AccountKeypair } from '../../src/relayclient/AccountManager'
+import { bufferToHex } from 'ethereumjs-util'
 
 const StakeManager = artifacts.require('StakeManager')
 const TestPaymasterConfigurableMisbehavior = artifacts.require('TestPaymasterConfigurableMisbehavior')
@@ -80,13 +82,14 @@ contract('KnownRelaysManager', function (
         chainId: env.chainId
       })
       contractInteractor = new ContractInteractor(web3.currentProvider as HttpProvider, config)
+      const senderAddress: AccountKeypair = getGaslessAccount()
+
       await contractInteractor.init()
 
       testRecipient = await TestRecipient.new()
       sWalletTemplate = await SmartWallet.new()
-      const senderAddress: string = (await web3.eth.getAccounts())[0]
       factory = await createProxyFactory(sWalletTemplate)
-      smartWallet = await createSmartWallet(senderAddress, factory, env.chainId)
+      smartWallet = await createSmartWallet(senderAddress.address, factory, env.chainId, bufferToHex(senderAddress.privateKey))
       // register hub's RelayRequest with forwarder, if not already done.
 
       paymaster = await TestPaymasterConfigurableMisbehavior.new()
@@ -99,7 +102,7 @@ contract('KnownRelaysManager', function (
       await stake(stakeManager, relayHub, activeTransactionRelayed, owner)
       await stake(stakeManager, relayHub, notActiveRelay, owner)
 
-      const other = await getGaslessAccount()
+      const other = getGaslessAccount()
       const nextNonce = (await smartWallet.getNonce()).toString()
       const txPaymasterRejected = await prepareTransaction(testRecipient, other, workerPaymasterRejected, paymaster.address, web3, nextNonce, smartWallet.address)
       const txTransactionRelayed = await prepareTransaction(testRecipient, other, workerTransactionRelayed, paymaster.address, web3, nextNonce, smartWallet.address)

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -38,6 +38,7 @@ import HttpWrapper from '../../src/relayclient/HttpWrapper'
 import { RelayTransactionRequest } from '../../src/relayclient/types/RelayTransactionRequest'
 import { AccountKeypair } from '../../src/relayclient/AccountManager'
 import { soliditySha3Raw } from 'web3-utils'
+import { bufferToHex } from 'ethereumjs-util'
 
 const StakeManager = artifacts.require('StakeManager')
 const TestRecipient = artifacts.require('TestRecipient')
@@ -98,9 +99,9 @@ contract('RelayClient', function (accounts) {
     sWalletTemplate = await SmartWallet.new()
     token = await TestToken.new()
     const env = (await getTestingEnvironment())
-    gaslessAccount = await getGaslessAccount()
+    gaslessAccount = getGaslessAccount()
     factory = await createProxyFactory(sWalletTemplate)
-    smartWallet = await createSmartWallet(gaslessAccount.address, factory, env.chainId, '0x' + gaslessAccount.privateKey.toString('hex'))
+    smartWallet = await createSmartWallet(gaslessAccount.address, factory, env.chainId, bufferToHex(gaslessAccount.privateKey))
     paymaster = await TestEnvelopingPaymaster.new()
     await paymaster.setRelayHub(relayHub.address)
     await paymaster.deposit({ value: web3.utils.toWei('1', 'ether') })
@@ -288,7 +289,7 @@ contract('RelayClient', function (accounts) {
     // Do we want to restrict to certnain factories?
 
     it('should calculate the estimatedGas for deploying a SmartWallet using the ProxyFactory', async function () {
-      const eoaWithoutSmartWalletAccount = await getGaslessAccount()
+      const eoaWithoutSmartWalletAccount = getGaslessAccount()
 
       // register eoaWithoutSmartWalletAccount account in RelayClient to avoid signing with RSKJ
       relayClient.accountManager.addAccount(eoaWithoutSmartWalletAccount)
@@ -320,7 +321,7 @@ contract('RelayClient', function (accounts) {
     })
 
     it('should send a SmartWallet create transaction to a relay and receive a signed transaction in response', async function () {
-      const eoaWithoutSmartWalletAccount = await getGaslessAccount()
+      const eoaWithoutSmartWalletAccount = getGaslessAccount()
 
       // register eoaWithoutSmartWallet account to avoid signing with RSKJ
       relayClient.accountManager.addAccount(eoaWithoutSmartWalletAccount)

--- a/test/relayclient/RelayProvider.test.ts
+++ b/test/relayclient/RelayProvider.test.ts
@@ -36,6 +36,7 @@ import TypedRequestData from '../../src/common/EIP712/TypedRequestData'
 import { constants } from '../../src/common/Constants'
 import GsnTransactionDetails from '../../src/relayclient/types/GsnTransactionDetails'
 import { AccountKeypair } from '../../src/relayclient/AccountManager'
+import { bufferToHex } from 'ethereumjs-util'
 
 const { expect, assert } = require('chai').use(chaiAsPromised)
 
@@ -112,7 +113,7 @@ contract('RelayProvider', function (accounts) {
 
   before(async function () {
     sender = accounts[0]
-    gaslessAccount = await getGaslessAccount()
+    gaslessAccount = getGaslessAccount()
 
     web3 = new Web3(underlyingProvider)
     stakeManager = await StakeManager.new()
@@ -121,7 +122,7 @@ contract('RelayProvider', function (accounts) {
     sWalletTemplate = await SmartWallet.new()
     const env = (await getTestingEnvironment())
     factory = await createProxyFactory(sWalletTemplate)
-    smartWallet = await createSmartWallet(gaslessAccount.address, factory, env.chainId, '0x' + gaslessAccount.privateKey.toString('hex'))
+    smartWallet = await createSmartWallet(gaslessAccount.address, factory, env.chainId, bufferToHex(gaslessAccount.privateKey))
     token = await TestToken.new()
 
     paymasterInstance = await TestPaymasterEverythingAccepted.new()
@@ -222,7 +223,7 @@ contract('RelayProvider', function (accounts) {
 
     it('should revert if the sender is not the owner of the smart wallet', async function () {
       try {
-        const differentSender = await getGaslessAccount()
+        const differentSender = getGaslessAccount()
         relayProvider.addAccount(differentSender)
         await testRecipient.emitMessage('hello world', {
           from: differentSender.address, // different sender
@@ -262,7 +263,7 @@ contract('RelayProvider', function (accounts) {
     )
 
     it('should fail to deploy the smart wallet due to insufficient token balance', async function () {
-      const ownerEOA = await getGaslessAccount()
+      const ownerEOA = getGaslessAccount()
       const recoverer = constants.ZERO_ADDRESS
       const customLogic = constants.ZERO_ADDRESS
       const logicData = '0x'
@@ -303,7 +304,7 @@ contract('RelayProvider', function (accounts) {
     })
 
     it('should correclty deploy the smart wallet', async function () {
-      const ownerEOA = await getGaslessAccount()
+      const ownerEOA = getGaslessAccount()
       const recoverer = constants.ZERO_ADDRESS
       const customLogic = constants.ZERO_ADDRESS
       const logicData = '0x'

--- a/test/relayserver/NetworkSimulation.test.ts
+++ b/test/relayserver/NetworkSimulation.test.ts
@@ -5,6 +5,7 @@ import { configureGSN, GSNConfig } from '../../src/relayclient/GSNConfigurator'
 import ContractInteractor from '../../src/relayclient/ContractInteractor'
 import { getTestingEnvironment, createProxyFactory, createSmartWallet, getGaslessAccount } from '../TestUtils'
 import { AccountKeypair } from '../../src/relayclient/AccountManager'
+import { bufferToHex } from 'ethereumjs-util'
 
 contract('Network Simulation for Relay Server', function (accounts) {
   let env: ServerTestEnvironment
@@ -40,12 +41,12 @@ contract('Network Simulation for Relay Server', function (accounts) {
     })
 
     it('should broadcast multiple transactions at once', async function () {
-      const gaslessAccount: AccountKeypair = await getGaslessAccount()
+      const gaslessAccount: AccountKeypair = getGaslessAccount()
 
       const SmartWallet = artifacts.require('SmartWallet')
       const sWalletTemplate = await SmartWallet.new()
       const factory = await createProxyFactory(sWalletTemplate)
-      const smartWallet = await createSmartWallet(gaslessAccount.address, factory, (await getTestingEnvironment()).chainId, '0x' + gaslessAccount.privateKey.toString('hex'))
+      const smartWallet = await createSmartWallet(gaslessAccount.address, factory, (await getTestingEnvironment()).chainId, bufferToHex(gaslessAccount.privateKey))
 
       env.relayClient.accountManager.addAccount(gaslessAccount)
 

--- a/test/relayserver/ServerTestEnvironment.ts
+++ b/test/relayserver/ServerTestEnvironment.ts
@@ -36,6 +36,7 @@ import RelayHubABI from '../../src/common/interfaces/IRelayHub.json'
 import StakeManagerABI from '../../src/common/interfaces/IStakeManager.json'
 import PayMasterABI from '../../src/common/interfaces/IPaymaster.json'
 import { RelayHubConfiguration } from '../../src/relayclient/types/RelayHubConfiguration'
+import { bufferToHex } from 'ethereumjs-util'
 
 const StakeManager = artifacts.require('StakeManager')
 const TestRecipient = artifacts.require('TestRecipient')
@@ -109,15 +110,14 @@ export class ServerTestEnvironment {
 
     this.encodedFunction = this.recipient.contract.methods.emitMessage('hello world').encodeABI()
 
-    // Get gasless account from RSKJ
-    const gaslessAccount = await getGaslessAccount()
+    const gaslessAccount = getGaslessAccount()
     this.gasLess = gaslessAccount.address
 
     const sWalletTemplate = await SmartWallet.new()
     const factory = await createProxyFactory(sWalletTemplate)
     const chainId = clientConfig.chainId ?? (await getTestingEnvironment()).chainId
 
-    const smartWallet: SmartWalletInstance = await createSmartWallet(this.gasLess, factory, chainId, '0x' + gaslessAccount.privateKey.toString('hex'))
+    const smartWallet: SmartWalletInstance = await createSmartWallet(this.gasLess, factory, chainId, bufferToHex(gaslessAccount.privateKey))
     this.forwarder = smartWallet
 
     const shared: Partial<GSNConfig> = {

--- a/test/smartwallet/SmartWallet.test.ts
+++ b/test/smartwallet/SmartWallet.test.ts
@@ -163,23 +163,25 @@ contract('SmartWallet', ([from]) => {
 
       it('should fail on unregistered domain separator', async () => {
         const dummyDomainSeparator = bytes32(1)
-
-        await expectRevert(sw.verify(req, dummyDomainSeparator, typeHash, '0x', '0x'.padEnd(65 * 2 + 2, '1b')), 'unregistered domain separator')
+        // TODO: when the RSKJ node includes the functionality to return the revert reason for require we need to remove the .unspecified from the expectRevert.
+        await expectRevert.unspecified(sw.verify(req, dummyDomainSeparator, typeHash, '0x', '0x'.padEnd(65 * 2 + 2, '1b')), 'unregistered domain separator')
       })
 
       it('should fail on wrong nonce', async () => {
         const env: Environment = await getTestingEnvironment()
         const message: string = isRsk(env) ? 'Returned error: VM execution error: nonce mismatch' : 'revert nonce mismatch'
 
-        await expectRevert(sw.verify({
+        // TODO: when the RSKJ node includes the functionality to return the revert reason for require we need to remove the .unspecified from the expectRevert.
+        await expectRevert.unspecified(sw.verify({
           ...req,
           nonce: 123
         }, domainSeparator, typeHash, '0x', '0x'), message)
       })
       it('should fail on invalid signature', async () => {
-        await expectRevert(sw.verify(req, domainSeparator, typeHash, '0x', '0x'), 'invalid signature length')
-        await expectRevert(sw.verify(req, domainSeparator, typeHash, '0x', '0x123456'), 'invalid signature length')
-        await expectRevert(sw.verify(req, domainSeparator, typeHash, '0x', '0x' + '1b'.repeat(65)), 'signature mismatch')
+        // TODO: when the RSKJ node includes the functionality to return the revert reason for require we need to remove the .unspecified from the expectRevert.
+        await expectRevert.unspecified(sw.verify(req, domainSeparator, typeHash, '0x', '0x'), 'invalid signature length')
+        await expectRevert.unspecified(sw.verify(req, domainSeparator, typeHash, '0x', '0x123456'), 'invalid signature length')
+        await expectRevert.unspecified(sw.verify(req, domainSeparator, typeHash, '0x', '0x' + '1b'.repeat(65)), 'signature mismatch')
       })
     })
     describe('#verify success', () => {


### PR DESCRIPTION
- Added getLocalEip712Signature function as a replacement for getEip712Signature in order to avoid signing typed data with RSKJ.
- Calls to getEip712Signature function replaced by calls to getLocalEip712Signature.
- Modifications to run Enveloping with latest version of RSKJ instead of a custom branch.
- Upgraded contracts version string.