### PR TITLE
Check whether the Signed message was signed with the Zero PK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,8 @@ jobs: # a collection of steps
           test: "test/SampleRecipient.test.ts"
       - run_rskj_test:
           test: "test/StakeManager.test.ts"
+      - run_rskj_test:
+          test: "test/RSKAddressValidator.test.ts"
       - store_artifacts:
           path: ~/gls/logs
   Lint_Tsc: # Lint and other prechecks thread

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -98,7 +98,7 @@ contract Penalizer is IPenalizer{
                 "Legal relay transaction");
         }
         address relay = keccak256(abi.encodePacked(unsignedTx)).recover(signature);
-        require(relay != address(0), "ecrecover failed");
+        require(RSKAddrValidator.checkPKNotZero(relay), "ecrecover failed");
 
         penalize(relay, hub);
     }

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/cryptography/ECDSA.sol";
 
 import "./utils/RLPReader.sol";
 import "./utils/GsnUtils.sol";
+import "./utils/RSKAddrValidator.sol";
 import "./interfaces/IRelayHub.sol";
 import "./interfaces/IPenalizer.sol";
 
@@ -57,7 +58,7 @@ contract Penalizer is IPenalizer{
         address addr2 = keccak256(abi.encodePacked(unsignedTx2)).recover(signature2);
 
         require(addr1 == addr2, "Different signer");
-        require(addr1 != address(0), "ecrecover failed");
+        require(RSKAddrValidator.checkPKNotZero(addr1), "ecrecover failed");
 
         Transaction memory decodedTx1 = decodeTransaction(unsignedTx1);
         Transaction memory decodedTx2 = decodeTransaction(unsignedTx2);

--- a/contracts/factory/ProxyFactory.sol
+++ b/contracts/factory/ProxyFactory.sol
@@ -130,7 +130,7 @@ contract ProxyFactory is IProxyFactory {
         );
 
         bytes32 digest = keccak256(packed);
-        require(RSKAddrValidator.safeCompare(digest.recover(sig),owner), string(packed));
+        require(RSKAddrValidator.safeEquals(digest.recover(sig),owner), string(packed));
 
         bytes32 salt = keccak256(abi.encodePacked(owner, recoverer, logic, keccak256(initParams), index));
 
@@ -293,7 +293,7 @@ contract ProxyFactory is IProxyFactory {
                 keccak256(_getEncoded(req, requestTypeHash, suffixData))
             )
         );
-        require(RSKAddrValidator.safeCompare(digest.recover(sig), req.from), "signature mismatch");
+        require(RSKAddrValidator.safeEquals(digest.recover(sig), req.from), "signature mismatch");
     }
 
     function _verifyNonce(IForwarder.ForwardRequest memory req) internal view {

--- a/contracts/factory/ProxyFactory.sol
+++ b/contracts/factory/ProxyFactory.sol
@@ -4,6 +4,7 @@ pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/cryptography/ECDSA.sol";
 import "./IProxyFactory.sol";
+import "../utils/RSKAddrValidator.sol";
 
 //import "@nomiclabs/buidler/console.sol";
 /* solhint-disable no-inline-assembly */
@@ -129,7 +130,7 @@ contract ProxyFactory is IProxyFactory {
         );
 
         bytes32 digest = keccak256(packed);
-        require(digest.recover(sig) == owner, string(packed));
+        require(RSKAddrValidator.safeCompare(digest.recover(sig),owner), string(packed));
 
         bytes32 salt = keccak256(abi.encodePacked(owner, recoverer, logic, keccak256(initParams), index));
 
@@ -292,7 +293,7 @@ contract ProxyFactory is IProxyFactory {
                 keccak256(_getEncoded(req, requestTypeHash, suffixData))
             )
         );
-        require(digest.recover(sig) == req.from, "signature mismatch");
+        require(RSKAddrValidator.safeCompare(digest.recover(sig), req.from), "signature mismatch");
     }
 
     function _verifyNonce(IForwarder.ForwardRequest memory req) internal view {

--- a/contracts/forwarder/SmartWallet.sol
+++ b/contracts/forwarder/SmartWallet.sol
@@ -189,7 +189,7 @@ contract SmartWallet is IForwarder {
                 keccak256(_getEncoded(req, requestTypeHash, suffixData))
             )
         );
-        require(RSKAddrValidator.safeCompare(digest.recover(sig), req.from), "signature mismatch");
+        require(RSKAddrValidator.safeEquals(digest.recover(sig), req.from), "signature mismatch");
     }
 
     function _getEncoded(

--- a/contracts/forwarder/SmartWallet.sol
+++ b/contracts/forwarder/SmartWallet.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./IForwarder.sol";
 import "../utils/GsnUtils.sol";
+import "../utils/RSKAddrValidator.sol";
 
 /* solhint-disable no-inline-assembly */
 /* solhint-disable avoid-low-level-calls */
@@ -188,7 +189,7 @@ contract SmartWallet is IForwarder {
                 keccak256(_getEncoded(req, requestTypeHash, suffixData))
             )
         );
-        require(digest.recover(sig) == req.from, "signature mismatch");
+        require(RSKAddrValidator.safeCompare(digest.recover(sig), req.from), "signature mismatch");
     }
 
     function _getEncoded(

--- a/contracts/test/TestRSKAddressValidator.sol
+++ b/contracts/test/TestRSKAddressValidator.sol
@@ -7,12 +7,17 @@ import "@openzeppelin/contracts/cryptography/ECDSA.sol";
 contract TestRSKAddressValidator {
     using ECDSA for bytes32;
 
-    function getSig(bytes32 messageHash, bytes memory sig) public returns (address) {
+    function getAddress(bytes32 messageHash, bytes memory sig) public returns (address) {
         return messageHash.recover(sig);
     }
 
     function compareAddressWithZeroPK(bytes32 messageHash, bytes memory sig) external returns (bool) {
-        address addr = this.getSig(messageHash, sig);
+        address addr = this.getAddress(messageHash, sig);
         return RSKAddrValidator.checkPKNotZero(addr);
+    }
+
+    function compareAddressWithSigner(bytes32 messageHash, bytes memory sig, address addr2) external returns (bool) {
+        address addr1 = this.getAddress(messageHash, sig);
+        return addr1 == addr2;
     }
 }

--- a/contracts/test/TestRSKAddressValidator.sol
+++ b/contracts/test/TestRSKAddressValidator.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier:MIT
+pragma solidity ^0.6.2;
+
+import "../utils/RSKAddrValidator.sol";
+import "@openzeppelin/contracts/cryptography/ECDSA.sol";
+
+contract TestRSKAddressValidator {
+    using ECDSA for bytes32;
+
+    function getSig(bytes32 messageHash, bytes memory sig) public returns (address) {
+        return messageHash.recover(sig);
+    }
+
+    function compareAddressWithZeroPK(bytes32 messageHash, bytes memory sig) external returns (bool) {
+        address addr = this.getSig(messageHash, sig);
+        return RSKAddrValidator.checkPKNotZero(addr);
+    }
+}

--- a/contracts/utils/RSKAddrCompatibility.sol
+++ b/contracts/utils/RSKAddrCompatibility.sol
@@ -1,0 +1,20 @@
+/* solhint-disable no-inline-assembly */
+// SPDX-License-Identifier:MIT
+pragma solidity ^0.6.2;
+
+library RSKAddrCompatibility {
+
+    address constant public ZERO_PK_ADDR = 0xdcc703c0E500B653Ca82273B7BFAd8045D85a470;
+
+    /*
+    * @param addr it is an address to check that it does not originates from 
+    * signing with PK = ZERO. RSK has a small difference in which @ZERO_PK_ADDR is 
+    * also an address from PK = ZERO. So we check for both of them.
+    */
+    function checkPKNotZero(address addr) external returns (bool){
+        if (addr == address(0) || addr == ZERO_PK_ADDR) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/contracts/utils/RSKAddrValidator.sol
+++ b/contracts/utils/RSKAddrValidator.sol
@@ -9,7 +9,7 @@ library RSKAddrValidator {
     * also an address from PK = ZERO. So we check for both of them.
     */
     function checkPKNotZero(address addr) internal pure returns (bool){
-        return (addr != address(0) && addr != 0xdcc703c0E500B653Ca82273B7BFAd8045D85a470);
+        return (addr != 0xdcc703c0E500B653Ca82273B7BFAd8045D85a470 && addr != address(0));
     }
 
     /*

--- a/contracts/utils/RSKAddrValidator.sol
+++ b/contracts/utils/RSKAddrValidator.sol
@@ -3,27 +3,23 @@
 pragma solidity ^0.6.2;
 
 library RSKAddrValidator {
-
-    address constant public ZERO_PK_ADDR = 0xdcc703c0E500B653Ca82273B7BFAd8045D85a470;
-
+    
     /*
     * @param addr it is an address to check that it does not originates from 
     * signing with PK = ZERO. RSK has a small difference in which @ZERO_PK_ADDR is 
     * also an address from PK = ZERO. So we check for both of them.
     */
     function checkPKNotZero(address addr) internal pure returns (bool){
-        if (addr == address(0) || addr == ZERO_PK_ADDR) {
-            return false;
-        }
-        return true;
+        return (addr != address(0) && addr != 0xdcc703c0E500B653Ca82273B7BFAd8045D85a470);
     }
 
     /*
     * Safely compares two addresses, checking they do not originate from
     * a zero private key
     */
-    function safeCompare(address addr1, address addr2) internal pure returns (bool){
-        require(checkPKNotZero(addr1) && checkPKNotZero(addr2), "Invalid address");
-        return addr1 == addr2;
+    function safeEquals(address addr1, address addr2) internal pure returns (bool){
+        return (addr1 == addr2 &&
+        addr1 != 0xdcc703c0E500B653Ca82273B7BFAd8045D85a470 &&
+        addr1 != address(0));
     }
 }

--- a/contracts/utils/RSKAddrValidator.sol
+++ b/contracts/utils/RSKAddrValidator.sol
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier:MIT
 pragma solidity ^0.6.2;
 
-library RSKAddrCompatibility {
+library RSKAddrValidator {
 
     address constant public ZERO_PK_ADDR = 0xdcc703c0E500B653Ca82273B7BFAd8045D85a470;
 
@@ -11,10 +11,19 @@ library RSKAddrCompatibility {
     * signing with PK = ZERO. RSK has a small difference in which @ZERO_PK_ADDR is 
     * also an address from PK = ZERO. So we check for both of them.
     */
-    function checkPKNotZero(address addr) external returns (bool){
+    function checkPKNotZero(address addr) internal pure returns (bool){
         if (addr == address(0) || addr == ZERO_PK_ADDR) {
             return false;
         }
         return true;
+    }
+
+    /*
+    * Safely compares two addresses, checking they do not originate from
+    * a zero private key
+    */
+    function safeCompare(address addr1, address addr2) internal pure returns (bool){
+        require(checkPKNotZero(addr1) && checkPKNotZero(addr2), "Invalid address");
+        return addr1 == addr2;
     }
 }

--- a/contracts/utils/RSKAddrValidator.sol
+++ b/contracts/utils/RSKAddrValidator.sol
@@ -1,9 +1,8 @@
-/* solhint-disable no-inline-assembly */
 // SPDX-License-Identifier:MIT
 pragma solidity ^0.6.2;
 
 library RSKAddrValidator {
-    
+
     /*
     * @param addr it is an address to check that it does not originates from 
     * signing with PK = ZERO. RSK has a small difference in which @ZERO_PK_ADDR is 

--- a/test/RSKAddressValidator.test.ts
+++ b/test/RSKAddressValidator.test.ts
@@ -1,0 +1,25 @@
+import {
+    TestRSKAddressValidatorInstance
+  } from '../types/truffle-contracts'
+
+const TestRSKAddressValidator = artifacts.require('TestRSKAddressValidator')
+  
+contract('RSKAddressValidator', function (accounts) {
+    let addressValidator: TestRSKAddressValidatorInstance
+    it("should return true on check with data signed with zero", async function () {
+      let messageHash = "0xf7cf90057f86838e5efd677f4741003ab90910e4e2736ff4d7999519d162d1ed"
+
+      let v = 27
+      let r = "3fba4230c7b08aa69affd0b7425b8666eb5e7d36f9ef84efeee5ba612c8df0bc"
+      let s = "6b212d83adb8364e5519a051894f4a513b7eb68d087d710bf21e70775d31a97b"
+
+      let signature = `0x${r}${s}${v.toString(16)}`
+
+      addressValidator = await TestRSKAddressValidator.new()
+      const addr = await addressValidator.getSig.call(messageHash, signature)
+      expect(addr).to.be.equal("0xdcc703c0E500B653Ca82273B7BFAd8045D85a470")
+
+      const res = await addressValidator.compareAddressWithZeroPK.call(messageHash, signature)
+      expect(res).to.be.equal(false)
+    })
+  })

--- a/test/RSKAddressValidator.test.ts
+++ b/test/RSKAddressValidator.test.ts
@@ -1,42 +1,42 @@
 import {
-    TestRSKAddressValidatorInstance
-  } from '../types/truffle-contracts'
+  TestRSKAddressValidatorInstance
+} from '../types/truffle-contracts'
 
 const TestRSKAddressValidator = artifacts.require('TestRSKAddressValidator')
-  
+
 contract('RSKAddressValidator', function (accounts) {
-    let addressValidator: TestRSKAddressValidatorInstance
-    it("should return true on check with data signed with zero", async function () {
-      let messageHash = "0xf7cf90057f86838e5efd677f4741003ab90910e4e2736ff4d7999519d162d1ed"
+  let addressValidator: TestRSKAddressValidatorInstance
+  it('should return true on check with data signed with zero', async function () {
+    const messageHash = '0xf7cf90057f86838e5efd677f4741003ab90910e4e2736ff4d7999519d162d1ed'
 
-      let v = 27
-      let r = "3fba4230c7b08aa69affd0b7425b8666eb5e7d36f9ef84efeee5ba612c8df0bc"
-      let s = "6b212d83adb8364e5519a051894f4a513b7eb68d087d710bf21e70775d31a97b"
+    const v = 27
+    const r = '3fba4230c7b08aa69affd0b7425b8666eb5e7d36f9ef84efeee5ba612c8df0bc'
+    const s = '6b212d83adb8364e5519a051894f4a513b7eb68d087d710bf21e70775d31a97b'
 
-      let signature = `0x${r}${s}${v.toString(16)}`
+    const signature = `0x${r}${s}${v.toString(16)}`
 
-      addressValidator = await TestRSKAddressValidator.new()
-      const addr = await addressValidator.getSig.call(messageHash, signature)
-      expect(addr).to.be.equal("0xdcc703c0E500B653Ca82273B7BFAd8045D85a470")
+    addressValidator = await TestRSKAddressValidator.new()
+    const addr = await addressValidator.getSig.call(messageHash, signature)
+    expect(addr).to.be.equal('0xdcc703c0E500B653Ca82273B7BFAd8045D85a470')
 
-      const res = await addressValidator.compareAddressWithZeroPK.call(messageHash, signature)
-      expect(res).to.be.equal(false)
-    })
-
-    it("should return true on check with data signed with zero with message hash from tx", async function () {
-      let messageHash = "0x4d3e45a3a5908513a10012e30a04fb2b438bab7da2acb93084e2f15a5eb55e8b"
-
-      let v = 27
-      let r = "90ef8cbc9ce5999887d32f3f5adf5292ada96b9506b51980f219d60271cf300c"
-      let s = "3e59fb0088da48b32cb4d83f17af47dd7340cd0dab15ac214b7039b65ee8876d"
-
-      let signature = `0x${r}${s}${v.toString(16)}`
-
-      addressValidator = await TestRSKAddressValidator.new()
-      const addr = await addressValidator.getSig.call(messageHash, signature)
-      expect(addr).to.be.equal("0xdcc703c0E500B653Ca82273B7BFAd8045D85a470")
-
-      const res = await addressValidator.compareAddressWithZeroPK.call(messageHash, signature)
-      expect(res).to.be.equal(false)
-    })
+    const res = await addressValidator.compareAddressWithZeroPK.call(messageHash, signature)
+    expect(res).to.be.equal(false)
   })
+
+  it('should return true on check with data signed with zero with message hash from tx', async function () {
+    const messageHash = '0x4d3e45a3a5908513a10012e30a04fb2b438bab7da2acb93084e2f15a5eb55e8b'
+
+    const v = 27
+    const r = '90ef8cbc9ce5999887d32f3f5adf5292ada96b9506b51980f219d60271cf300c'
+    const s = '3e59fb0088da48b32cb4d83f17af47dd7340cd0dab15ac214b7039b65ee8876d'
+
+    const signature = `0x${r}${s}${v.toString(16)}`
+
+    addressValidator = await TestRSKAddressValidator.new()
+    const addr = await addressValidator.getSig.call(messageHash, signature)
+    expect(addr).to.be.equal('0xdcc703c0E500B653Ca82273B7BFAd8045D85a470')
+
+    const res = await addressValidator.compareAddressWithZeroPK.call(messageHash, signature)
+    expect(res).to.be.equal(false)
+  })
+})

--- a/test/RSKAddressValidator.test.ts
+++ b/test/RSKAddressValidator.test.ts
@@ -69,11 +69,11 @@ contract('RSKAddressValidator', function (accounts) {
 
     addressValidator = await TestRSKAddressValidator.new()
     const areEqualSmallCase = await addressValidator.compareAddressWithSigner.call(messageHash, signature, addr)
-    expect(areEqualSmallCase).to.be.true;
+    expect(areEqualSmallCase).to.be.true
 
     const addrChecksummed = toChecksumAddress(addr)
 
     const areEqualChecksummed = await addressValidator.compareAddressWithSigner.call(messageHash, signature, addrChecksummed)
-    expect(areEqualChecksummed).to.be.true;
+    expect(areEqualChecksummed).to.be.true
   })
 })

--- a/test/RSKAddressValidator.test.ts
+++ b/test/RSKAddressValidator.test.ts
@@ -22,4 +22,21 @@ contract('RSKAddressValidator', function (accounts) {
       const res = await addressValidator.compareAddressWithZeroPK.call(messageHash, signature)
       expect(res).to.be.equal(false)
     })
+
+    it("should return true on check with data signed with zero with message hash from tx", async function () {
+      let messageHash = "0x4d3e45a3a5908513a10012e30a04fb2b438bab7da2acb93084e2f15a5eb55e8b"
+
+      let v = 27
+      let r = "90ef8cbc9ce5999887d32f3f5adf5292ada96b9506b51980f219d60271cf300c"
+      let s = "3e59fb0088da48b32cb4d83f17af47dd7340cd0dab15ac214b7039b65ee8876d"
+
+      let signature = `0x${r}${s}${v.toString(16)}`
+
+      addressValidator = await TestRSKAddressValidator.new()
+      const addr = await addressValidator.getSig.call(messageHash, signature)
+      expect(addr).to.be.equal("0xdcc703c0E500B653Ca82273B7BFAd8045D85a470")
+
+      const res = await addressValidator.compareAddressWithZeroPK.call(messageHash, signature)
+      expect(res).to.be.equal(false)
+    })
   })

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -376,7 +376,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
             assert.notEqual(resultEvent, null, 'didn\'t get TrasnactionResult where it should.')
           }
 
-          const rskDiff: number = isRsk(env) ? 3135 : 0
+          const rskDiff: number = isRsk(env) ? 3042 : 0
           const gasUsed: number = res.receipt.gasUsed
           const diff = await diffBalances(await beforeBalances)
 


### PR DESCRIPTION
A new method is introduced to check if a message was signed with a private key equal to zero.

This is necessary because there are cases in which the resulting address, which should be zero, is not.

