### PR TITLE
Equivalent optimizations

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,7 +1,8 @@
 {
   "extends": "solhint:recommended",
   "rules": {
-    "compiler-version": ["error","^0.6.2"],
-    "mark-callable-contracts": ["off"]
+    "compiler-version": ["error","^0.6.12"],
+    "mark-callable-contracts": ["off"],
+    "reason-string": ["warn",{"maxLength":32}]
   }
 }

--- a/contracts/BaseRelayRecipient.sol
+++ b/contracts/BaseRelayRecipient.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier:MIT
 // solhint-disable no-inline-assembly
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 /**
  * A base contract to be inherited by any contract that want to receive relayed transactions

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 contract Migrations {
     address public owner;

--- a/contracts/Penalizer.sol
+++ b/contracts/Penalizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/cryptography/ECDSA.sol";

--- a/contracts/StakeManager.sol
+++ b/contracts/StakeManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
@@ -28,7 +28,7 @@ contract StakeManager is IStakeManager {
     function stakeForAddress(address relayManager, uint256 unstakeDelay) external override payable {
         require(stakes[relayManager].owner == address(0) || stakes[relayManager].owner == msg.sender, "not owner");
         require(unstakeDelay >= stakes[relayManager].unstakeDelay, "unstakeDelay cannot be decreased");
-        require(msg.sender != relayManager, "relayManager cannot stake for itself");
+        require(msg.sender != relayManager, "caller is the relayManager");
         require(stakes[msg.sender].owner == address(0), "sender is a relayManager itself");
         stakes[relayManager].owner = msg.sender;
         stakes[relayManager].stake += msg.value;

--- a/contracts/factory/IProxyFactory.sol
+++ b/contracts/factory/IProxyFactory.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.6.12 <0.8.0;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../forwarder/IForwarder.sol";
 
 interface IProxyFactory {
 
-    function getNonce(address from) external view returns(uint256);
+    function nonce (address from) external view returns(uint256);
 
     function createUserSmartWallet(
         address owner,
@@ -21,7 +21,7 @@ interface IProxyFactory {
         IForwarder.ForwardRequest memory req,
         bytes32 domainSeparator,
         bytes32 requestTypeHash,
-        bytes calldata suffixData,
+        bytes32 suffixData,
         bytes calldata sig
     ) external;
 

--- a/contracts/forwarder/IForwarder.sol
+++ b/contracts/forwarder/IForwarder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 interface IForwarder {
@@ -19,7 +19,7 @@ interface IForwarder {
         uint256 index; // only used in SmartWallet deploy requests
     }
 
-    function getNonce()
+    function nonce()
     external view
     returns(uint256);
 
@@ -32,7 +32,7 @@ interface IForwarder {
         ForwardRequest calldata forwardRequest,
         bytes32 domainSeparator,
         bytes32 requestTypeHash,
-        bytes calldata suffixData,
+        bytes32 suffixData,
         bytes calldata signature
     ) external view;
 
@@ -53,7 +53,7 @@ interface IForwarder {
         ForwardRequest calldata forwardRequest,
         bytes32 domainSeparator,
         bytes32 requestTypeHash,
-        bytes calldata suffixData,
+        bytes32 suffixData,
         bytes calldata signature
     )
     external payable

--- a/contracts/forwarder/test/TestForwarderTarget.sol
+++ b/contracts/forwarder/test/TestForwarderTarget.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 contract TestForwarderTarget {
 

--- a/contracts/forwarder/test/TestSmartWallet.sol
+++ b/contracts/forwarder/test/TestSmartWallet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../SmartWallet.sol";
@@ -7,7 +7,7 @@ import "../SmartWallet.sol";
 // helper class for testing the forwarder.
 contract TestSmartWallet {
     function callExecute(SmartWallet sw, SmartWallet.ForwardRequest memory req,
-        bytes32 domainSeparator, bytes32 requestTypeHash, bytes memory suffixData, bytes memory sig) public payable {
+        bytes32 domainSeparator, bytes32 requestTypeHash, bytes32 suffixData, bytes memory sig) public payable {
          (bool success, uint256 lastSuccTx, bytes memory ret) = sw.execute{value:msg.value}(req, domainSeparator, requestTypeHash, suffixData, sig);
        
         emit Result(success, success ? "" : this.decodeErrorMessage(ret), lastSuccTx);

--- a/contracts/forwarder/test/TestToken.sol
+++ b/contracts/forwarder/test/TestToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/interfaces/GsnTypes.sol
+++ b/contracts/interfaces/GsnTypes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 import "../forwarder/IForwarder.sol";
 

--- a/contracts/interfaces/IKnowForwarderAddress.sol
+++ b/contracts/interfaces/IKnowForwarderAddress.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 interface IKnowForwarderAddress {
 

--- a/contracts/interfaces/IPaymaster.sol
+++ b/contracts/interfaces/IPaymaster.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./GsnTypes.sol";

--- a/contracts/interfaces/IPenalizer.sol
+++ b/contracts/interfaces/IPenalizer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 import "./IRelayHub.sol";
 

--- a/contracts/interfaces/IRelayHub.sol
+++ b/contracts/interfaces/IRelayHub.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./GsnTypes.sol";

--- a/contracts/interfaces/IStakeManager.sol
+++ b/contracts/interfaces/IStakeManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/interfaces/IVersionRegistry.sol
+++ b/contracts/interfaces/IVersionRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 interface IVersionRegistry {
 

--- a/contracts/paymaster/BasePaymaster.sol
+++ b/contracts/paymaster/BasePaymaster.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.10;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -51,7 +51,7 @@ abstract contract BasePaymaster is IPaymaster, Ownable {
      * modifier to be used by recipients as access control protection for preRelayedCall & postRelayedCall
      */
     modifier relayHubOnly() {
-        require(msg.sender == getHubAddr(), "Function can only be called by RelayHub");
+        require(msg.sender == getHubAddr(), "Caller is not the RelayHub");
         _;
     }
 

--- a/contracts/paymaster/DeployPaymaster.sol
+++ b/contracts/paymaster/DeployPaymaster.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
 import "../factory/ProxyFactory.sol";
 import "./BasePaymaster.sol";
+import "../utils/GsnUtils.sol";
 
 /**
  * A paymaster to be used on deploys.
@@ -41,7 +41,7 @@ contract DeployPaymaster is BasePaymaster {
     returns (bytes memory context, bool revertOnRecipientRevert) {
         require(tokens[relayRequest.request.tokenContract], "Token contract not allowed");
     
-        require(relayRequest.request.factory == factory, "factory should be the trusted one!");
+        require(relayRequest.request.factory == factory, "Invalid factory");
 
         address contractAddr = ProxyFactory(relayRequest.request.factory)
             .getSmartWalletAddress(

--- a/contracts/paymaster/RelayPaymaster.sol
+++ b/contracts/paymaster/RelayPaymaster.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/test/PayableWithEmit.sol
+++ b/contracts/test/PayableWithEmit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 //make sure that "payable" function that uses _msgSender() still works
 // (its not required to use _msgSender(), since the default function

--- a/contracts/test/TestEnvelopingPaymaster.sol
+++ b/contracts/test/TestEnvelopingPaymaster.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../paymaster/BasePaymaster.sol";

--- a/contracts/test/TestPaymasterConfigurableMisbehavior.sol
+++ b/contracts/test/TestPaymasterConfigurableMisbehavior.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./TestPaymasterEverythingAccepted.sol";
@@ -70,7 +70,7 @@ contract TestPaymasterConfigurableMisbehavior is TestPaymasterEverythingAccepted
             withdrawAllBalance();
         }
         if (revertPreRelayCall) {
-            revert("You asked me to revert, remember?");
+            revert("revertPreRelayCall: Reverting");
         }
         return ("", trustRecipientRevert);
     }
@@ -90,7 +90,7 @@ contract TestPaymasterConfigurableMisbehavior is TestPaymasterEverythingAccepted
             withdrawAllBalance();
         }
         if (revertPostRelayCall) {
-            revert("You asked me to revert, remember?");
+            revert("revertPreRelayCall: Reverting");
         }
     }
 

--- a/contracts/test/TestPaymasterEverythingAccepted.sol
+++ b/contracts/test/TestPaymasterEverythingAccepted.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../paymaster/BasePaymaster.sol";

--- a/contracts/test/TestPaymasterOwnerSignature.sol
+++ b/contracts/test/TestPaymasterOwnerSignature.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/cryptography/ECDSA.sol";

--- a/contracts/test/TestPaymasterPreconfiguredApproval.sol
+++ b/contracts/test/TestPaymasterPreconfiguredApproval.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./TestPaymasterEverythingAccepted.sol";

--- a/contracts/test/TestPaymasterStoreContext.sol
+++ b/contracts/test/TestPaymasterStoreContext.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./TestPaymasterEverythingAccepted.sol";

--- a/contracts/test/TestPaymasterVariableGasLimits.sol
+++ b/contracts/test/TestPaymasterVariableGasLimits.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "./TestPaymasterEverythingAccepted.sol";

--- a/contracts/test/TestPaymasters.sol
+++ b/contracts/test/TestPaymasters.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../interfaces/IPaymaster.sol";

--- a/contracts/test/TestRSKAddressValidator.sol
+++ b/contracts/test/TestRSKAddressValidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 import "../utils/RSKAddrValidator.sol";
 import "@openzeppelin/contracts/cryptography/ECDSA.sol";

--- a/contracts/test/TestRecipient.sol
+++ b/contracts/test/TestRecipient.sol
@@ -1,6 +1,6 @@
 /* solhint-disable avoid-tx-origin */
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 import "../utils/GsnUtils.sol";
 import "./TestPaymasterConfigurableMisbehavior.sol";
@@ -38,6 +38,12 @@ contract TestRecipient {
         return "emitMessage return value";
     }
 
+    function emitMessage2(string memory message) public payable returns (string memory) {
+
+        emit SampleRecipientEmitted(message, msg.sender, tx.origin, msg.value, address(this).balance);
+        return "emitMessage return value";
+    }
+
     function withdrawAllBalance() public {
         TestPaymasterConfigurableMisbehavior(paymaster).withdrawAllBalance();
     }
@@ -65,6 +71,7 @@ contract TestRecipient {
     //function with no return value (also test revert with no msg.
     function checkNoReturnValues(bool doRevert) public view {
         (this);
+        /* solhint-disable-next-line reason-string */
         require(!doRevert);
     }
 

--- a/contracts/test/TestRelayWorkerContract.sol
+++ b/contracts/test/TestRelayWorkerContract.sol
@@ -1,6 +1,6 @@
 /* solhint-disable avoid-tx-origin */
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../interfaces/IRelayHub.sol";

--- a/contracts/test/TestUtil.sol
+++ b/contracts/test/TestUtil.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../interfaces/GsnTypes.sol";
@@ -9,11 +9,11 @@ import "../utils/GsnUtils.sol";
 contract TestUtil {
 
     function libRelayRequestName() public pure returns (string memory) {
-        return GsnEip712Library.RELAY_REQUEST_NAME;
+        return "RelayRequest";
     }
 
     function libRelayRequestType() public pure returns (string memory) {
-        return string(GsnEip712Library.RELAY_REQUEST_TYPE);
+        return "RelayRequest(address from,address to,uint256 value,uint256 gas,uint256 nonce,bytes data,address tokenRecipient,address tokenContract,uint256 tokenAmount,address factory,address recoverer,uint256 index,RelayData relayData)RelayData(uint256 gasPrice,uint256 pctRelayFee,uint256 baseRelayFee,address relayWorker,address paymaster,address forwarder,bytes paymasterData,uint256 clientId)";
     }
 
     function libRelayRequestTypeHash() public pure returns (bytes32) {
@@ -21,7 +21,7 @@ contract TestUtil {
     }
 
     function libRelayRequestSuffix() public pure returns (string memory) {
-        return GsnEip712Library.RELAY_REQUEST_SUFFIX;
+        return "RelayData relayData)RelayData(uint256 gasPrice,uint256 pctRelayFee,uint256 baseRelayFee,address relayWorker,address paymaster,address forwarder,bytes paymasterData,uint256 clientId)";
     }
 
     //helpers for test to call the library funcs:
@@ -31,7 +31,7 @@ contract TestUtil {
     )
     external
     view {
-        GsnEip712Library.verify(relayRequest, signature);
+        GsnEip712Library.verifySignature(relayRequest, signature);
     }
 
     function callForwarderVerifyAndCall(
@@ -62,7 +62,7 @@ contract TestUtil {
     returns (
         IForwarder.ForwardRequest memory forwardRequest,
         bytes32 typeHash,
-        bytes memory suffixData
+        bytes32 suffixData
     ) {
         (forwardRequest, suffixData) = GsnEip712Library.splitRequest(relayRequest);
         typeHash = GsnEip712Library.RELAY_REQUEST_TYPEHASH;
@@ -84,7 +84,7 @@ contract TestUtil {
             verifyingContract : forwarder
         });
         return abi.encode(
-                GsnEip712Library.EIP712DOMAIN_TYPEHASH,
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"), // EIP712DOMAIN_TYPEHASH
                 keccak256(bytes(req.name)),
                 keccak256(bytes(req.version)),
                 req.chainId,
@@ -94,7 +94,7 @@ contract TestUtil {
 
     function libEncodedData(GsnTypes.RelayData memory req) public pure returns (bytes memory) {
         return abi.encode(
-                GsnEip712Library.RELAYDATA_TYPEHASH,
+                keccak256("RelayData(uint256 gasPrice,uint256 pctRelayFee,uint256 baseRelayFee,address relayWorker,address paymaster,address forwarder,bytes paymasterData,uint256 clientId)"), // RELAYDATA_TYPEHASH
                 req.gasPrice,
                 req.pctRelayFee,
                 req.baseRelayFee,

--- a/contracts/test/TestVersions.sol
+++ b/contracts/test/TestVersions.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 contract TestVersions {
 

--- a/contracts/utils/GsnEip712Library.sol
+++ b/contracts/utils/GsnEip712Library.sol
@@ -1,46 +1,23 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "../interfaces/GsnTypes.sol";
 import "../forwarder/IForwarder.sol";
 import "../factory/IProxyFactory.sol";
-
-import "./GsnUtils.sol";
-
+import "./MinLibBytes.sol";
 /**
- * Bridge Library to map GSN RelayRequest into a call of a Forwarder
+ * Bridge Library to map Enveloping RelayRequest into a call of a SmartWallet
  */
 library GsnEip712Library {
-    // maximum length of return value/revert reason for 'execute' method. Will truncate result if exceeded.
-    uint256 private constant MAX_RETURN_SIZE = 1024;
 
-    //copied from Forwarder (can't reference string constants even from another library)
-    string public constant GENERIC_PARAMS = "address from,address to,uint256 value,uint256 gas,uint256 nonce,bytes data,address tokenRecipient,address tokenContract,uint256 tokenAmount,address factory,address recoverer,uint256 index";
-
-    bytes public constant RELAYDATA_TYPE = "RelayData(uint256 gasPrice,uint256 pctRelayFee,uint256 baseRelayFee,address relayWorker,address paymaster,address forwarder,bytes paymasterData,uint256 clientId)";
-
-    string public constant RELAY_REQUEST_NAME = "RelayRequest";
-    string public constant RELAY_REQUEST_SUFFIX = string(abi.encodePacked("RelayData relayData)", RELAYDATA_TYPE));
-
-    bytes public constant RELAY_REQUEST_TYPE = abi.encodePacked(
-        RELAY_REQUEST_NAME,"(",GENERIC_PARAMS,",", RELAY_REQUEST_SUFFIX);
-
-    bytes32 public constant RELAYDATA_TYPEHASH = keccak256(RELAYDATA_TYPE);
-    bytes32 public constant RELAY_REQUEST_TYPEHASH = keccak256(RELAY_REQUEST_TYPE);
-
+    bytes32 public constant RELAY_REQUEST_TYPEHASH = keccak256("RelayRequest(address from,address to,uint256 value,uint256 gas,uint256 nonce,bytes data,address tokenRecipient,address tokenContract,uint256 tokenAmount,address factory,address recoverer,uint256 index,RelayData relayData)RelayData(uint256 gasPrice,uint256 pctRelayFee,uint256 baseRelayFee,address relayWorker,address paymaster,address forwarder,bytes paymasterData,uint256 clientId)");
     struct EIP712Domain {
         string name;
         string version;
         uint256 chainId;
         address verifyingContract;
     }
-
-    bytes32 public constant EIP712DOMAIN_TYPEHASH = keccak256(
-        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
-    );
-
-
 
     function splitRequest(
         GsnTypes.RelayRequest calldata req
@@ -49,7 +26,7 @@ library GsnEip712Library {
     pure
     returns (
         IForwarder.ForwardRequest memory forwardRequest,
-        bytes memory suffixData
+        bytes32 suffixData
     ) {
         forwardRequest = IForwarder.ForwardRequest(
             req.request.from,
@@ -65,38 +42,33 @@ library GsnEip712Library {
             req.request.recoverer,
             req.request.index
         );
-        suffixData = abi.encode(
-            hashRelayData(req.relayData));
+        suffixData = hashRelayData(req.relayData);
     }
 
     //verify that the recipient trusts the given forwarder
     // MUST be called by paymaster
 
-    function verifySignature(GsnTypes.RelayRequest calldata relayRequest, bytes calldata signature) internal view {
-        (IForwarder.ForwardRequest memory forwardRequest, bytes memory suffixData) = splitRequest(relayRequest);
-        IForwarder forwarder = IForwarder(payable(relayRequest.relayData.forwarder));
-        forwarder.verify(forwardRequest, domainSeparator(relayRequest.relayData.forwarder), RELAY_REQUEST_TYPEHASH, suffixData, signature);
+   function verifySignature(GsnTypes.RelayRequest calldata relayRequest, bytes calldata signature) internal view returns(bool callSuccess){
+        (IForwarder.ForwardRequest memory forwardRequest, bytes32 suffixData) = splitRequest(relayRequest);
+
+        (callSuccess,) = relayRequest.relayData.forwarder.staticcall(
+            abi.encodeWithSelector(
+                IForwarder.verify.selector,
+                forwardRequest,
+                domainSeparator(relayRequest.relayData.forwarder),
+                RELAY_REQUEST_TYPEHASH,
+                suffixData,
+                signature
+            )
+        );
     }
 
-    function verify(GsnTypes.RelayRequest calldata relayRequest, bytes calldata signature) internal view {
-        verifySignature(relayRequest, signature);
-    }
 
-        function execute(GsnTypes.RelayRequest calldata relayRequest, bytes calldata signature) internal returns (bool forwarderSuccess, bool callSuccess, uint256 lastSuccTx, bytes memory ret) {
-        (IForwarder.ForwardRequest memory forwardRequest, bytes memory suffixData) = splitRequest(relayRequest);
+    function execute(GsnTypes.RelayRequest calldata relayRequest, bytes calldata signature) internal returns (bool forwarderSuccess, bool callSuccess, uint256 lastSuccTx, bytes memory ret) {
+        (IForwarder.ForwardRequest memory forwardRequest, bytes32 suffixData) = splitRequest(relayRequest);
 
-        if(address(0)!= forwardRequest.factory){//Deploy of smart wallet
 
-            //The gas limit for the deploy creation is injected here, since the gasCalculation
-            //estimate is done against the whole relayedUserSmartWalletCreation function in
-            //the relayClient
-            /* solhint-disable-next-line avoid-low-level-calls */
-            (forwarderSuccess,) = forwardRequest.factory.call{gas: forwardRequest.gas}(
-                abi.encodeWithSelector(IProxyFactory.relayedUserSmartWalletCreation.selector,
-                forwardRequest, domainSeparator(forwardRequest.factory), RELAY_REQUEST_TYPEHASH, suffixData, signature
-            ));
-        }
-        else{
+        if(address(0) == forwardRequest.factory){
             /* solhint-disable-next-line avoid-low-level-calls */
             (forwarderSuccess, ret) = relayRequest.relayData.forwarder.call(
                 abi.encodeWithSelector(IForwarder.execute.selector,
@@ -110,13 +82,24 @@ library GsnEip712Library {
             }
             truncateInPlace(ret);
         }
+        else {
+            // Deploy of smart wallet
+            //The gas limit for the deploy creation is injected here, since the gasCalculation
+            //estimate is done against the whole relayedUserSmartWalletCreation function in
+            //the relayClient
+            /* solhint-disable-next-line avoid-low-level-calls */
+            (forwarderSuccess,) = forwardRequest.factory.call{gas: forwardRequest.gas}(
+                abi.encodeWithSelector(IProxyFactory.relayedUserSmartWalletCreation.selector,
+                forwardRequest, domainSeparator(forwardRequest.factory), RELAY_REQUEST_TYPEHASH, suffixData, signature
+            ));
+        }
     }
 
     //truncate the given parameter (in-place) if its length is above the given maximum length
     // do nothing otherwise.
     //NOTE: solidity warns unless the method is marked "pure", but it DOES modify its parameter.
     function truncateInPlace(bytes memory data) internal pure {
-        MinLibBytes.truncateInPlace(data, MAX_RETURN_SIZE);
+        MinLibBytes.truncateInPlace(data, 1024); // maximum length of return value/revert reason for 'execute' method. Will truncate result if exceeded.
     }
 
     function domainSeparator(address verifier) internal pure returns (bytes32) {
@@ -137,7 +120,7 @@ library GsnEip712Library {
 
     function hashDomain(EIP712Domain memory req) internal pure returns (bytes32) {
         return keccak256(abi.encode(
-                EIP712DOMAIN_TYPEHASH,
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"), // EIP712DOMAIN_TYPEHASH
                 keccak256(bytes(req.name)),
                 keccak256(bytes(req.version)),
                 req.chainId,
@@ -146,7 +129,7 @@ library GsnEip712Library {
 
     function hashRelayData(GsnTypes.RelayData calldata req) internal pure returns (bytes32) {
         return keccak256(abi.encode(
-                RELAYDATA_TYPEHASH,
+                keccak256("RelayData(uint256 gasPrice,uint256 pctRelayFee,uint256 baseRelayFee,address relayWorker,address paymaster,address forwarder,bytes paymasterData,uint256 clientId)"), // RELAYDATA_TYPEHASH
                 req.gasPrice,
                 req.pctRelayFee,
                 req.baseRelayFee,

--- a/contracts/utils/GsnUtils.sol
+++ b/contracts/utils/GsnUtils.sol
@@ -1,6 +1,6 @@
 /* solhint-disable no-inline-assembly */
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 import "../utils/MinLibBytes.sol";
 

--- a/contracts/utils/MinLibBytes.sol
+++ b/contracts/utils/MinLibBytes.sol
@@ -2,7 +2,7 @@
 // minimal bytes manipulation required by GSN
 // a minimal subset from 0x/LibBytes
 /* solhint-disable no-inline-assembly */
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 library MinLibBytes {
 

--- a/contracts/utils/RLPReader.sol
+++ b/contracts/utils/RLPReader.sol
@@ -3,7 +3,7 @@
 * Taken from https://github.com/hamdiallam/Solidity-RLP
 */
 /* solhint-disable */
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 library RLPReader {
 

--- a/contracts/utils/RSKAddrValidator.sol
+++ b/contracts/utils/RSKAddrValidator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 library RSKAddrValidator {
 

--- a/contracts/utils/VersionRegistry.sol
+++ b/contracts/utils/VersionRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 // solhint-disable not-rely-on-time
 
 import "../interfaces/IVersionRegistry.sol";

--- a/src/relayclient/ContractInteractor.ts
+++ b/src/relayclient/ContractInteractor.ts
@@ -231,13 +231,13 @@ export default class ContractInteractor {
 
   async getSenderNonce (sWallet: Address): Promise<IntString> {
     const forwarder = await this._createForwarder(sWallet)
-    const nonce = await forwarder.getNonce()
+    const nonce = await forwarder.nonce()
     return nonce.toString()
   }
 
   async getFactoryNonce (factoryAddr: Address, from: Address): Promise<IntString> {
     const factory = await this._createFactory(factoryAddr)
-    const nonce = await factory.getNonce(from)
+    const nonce = await factory.nonce(from)
     return nonce.toString()
   }
 

--- a/src/relayclient/RelayProvider.ts
+++ b/src/relayclient/RelayProvider.ts
@@ -168,7 +168,7 @@ export class RelayProvider implements HttpProvider {
       { t: 'bytes32', v: bytecodeHash }
     ) ?? ''
 
-    return toChecksumAddress('0x' + _data.slice(26, _data.length))
+    return toChecksumAddress('0x' + _data.slice(26, _data.length), this.config.chainId)
   }
 
   _ethGetTransactionReceipt (payload: JsonRpcPayload, callback: JsonRpcCallback): void {

--- a/test/Flows.test.ts
+++ b/test/Flows.test.ts
@@ -47,7 +47,6 @@ options.forEach(params => {
     let sm: StakeManagerInstance
     let relayproc: ChildProcessWithoutNullStreams
     let relayClientConfig: Partial<GSNConfig>
-
     let fundedAccount: AccountKeypair
     let gaslessAccount: AccountKeypair
 

--- a/test/GsnTestEnvironment.test.ts
+++ b/test/GsnTestEnvironment.test.ts
@@ -34,7 +34,7 @@ contract('GsnTestEnvironment', function () {
     })
 
     it('should relay using relayTransaction', async () => {
-      const sender = getGaslessAccount()
+      const sender = await getGaslessAccount()
       const proxyFactory: ProxyFactoryInstance = await ProxyFactory.at(testEnvironment.deploymentResult.factoryAddress)
       const sr: TestRecipientInstance = await TestRecipient.new()
 
@@ -76,7 +76,7 @@ contract('GsnTestEnvironment', function () {
     })
 
     it('should send relayed transaction through RelayProvider', async () => {
-      const sender = getGaslessAccount()
+      const sender = await getGaslessAccount()
       const proxyFactory: ProxyFactoryInstance = await ProxyFactory.at(testEnvironment.deploymentResult.factoryAddress)
       const sr: TestRecipientInstance = await TestRecipient.new()
 

--- a/test/PaymasterCommitment.test.ts
+++ b/test/PaymasterCommitment.test.ts
@@ -45,7 +45,7 @@ Promise<{ req: RelayRequest, sig: PrefixedHexString }> {
   }
   // unless explicitly set, read nonce from network.
   if ((filledRequest.request.nonce ?? '0') === '0') {
-    filledRequest.request.nonce = (await forwarderInstance.getNonce()).toString()
+    filledRequest.request.nonce = (await forwarderInstance.nonce()).toString()
   }
 
   const sig = getLocalEip712Signature(
@@ -96,7 +96,7 @@ contract('Paymaster Commitment', function ([_, relayOwner, relayManager, relayWo
   const pctRelayFee = '0'
 
   before(async function () {
-    gaslessAccount = getGaslessAccount()
+    gaslessAccount = await getGaslessAccount()
     stakeManager = await StakeManager.new()
     penalizer = await Penalizer.new()
     relayHubInstance = await deployHub(stakeManager.address, penalizer.address)

--- a/test/Paymasters.test.ts
+++ b/test/Paymasters.test.ts
@@ -43,7 +43,7 @@ contract('DeployPaymaster', function ([relayHub, dest, other1, relayWorker, send
   let expectedAddress: Address
 
   const ownerPrivateKey = toBuffer(bytes32(1))
-  const ownerAddress = toChecksumAddress(bufferToHex(privateToAddress(ownerPrivateKey)))
+  let ownerAddress: string
   const logicAddress = constants.ZERO_ADDRESS
   const initParams = '0x'
 
@@ -51,6 +51,7 @@ contract('DeployPaymaster', function ([relayHub, dest, other1, relayWorker, send
   const index = '0'
 
   beforeEach(async function () {
+    ownerAddress = toChecksumAddress(bufferToHex(privateToAddress(ownerPrivateKey)), (await getTestingEnvironment()).chainId).toLowerCase()
     token = await TestToken.new()
     template = await SmartWallet.new()
 
@@ -181,7 +182,7 @@ contract('DeployPaymaster', function ([relayHub, dest, other1, relayWorker, send
 
     await expectRevert.unspecified(
       testPaymasters.preRelayedCall(relayRequestData, '0x00', '0x00', 6, { from: relayHub }),
-      'factory should be the trusted one!'
+      'Invalid factory'
     )
   })
 })
@@ -196,11 +197,13 @@ contract('RelayPaymaster', function ([_, dest, relayManager, relayWorker, other,
   let testPaymasters: TestPaymastersInstance
 
   const senderPrivateKey = toBuffer(bytes32(1))
-  const senderAddress = toChecksumAddress(bufferToHex(privateToAddress(senderPrivateKey)))
+  let senderAddress: string
 
   before(async function () {
     const env = await getTestingEnvironment()
     const chainId = env.chainId
+
+    senderAddress = toChecksumAddress(bufferToHex(privateToAddress(senderPrivateKey)), chainId).toLowerCase()
 
     token = await TestToken.new()
     template = await SmartWallet.new()

--- a/test/RSKAddressValidator.test.ts
+++ b/test/RSKAddressValidator.test.ts
@@ -7,6 +7,11 @@ const TestRSKAddressValidator = artifacts.require('TestRSKAddressValidator')
 
 contract('RSKAddressValidator', function (accounts) {
   let addressValidator: TestRSKAddressValidatorInstance
+  // let chainId: number
+
+  before(async () => {
+    // chainId = (await getTestingEnvironment()).chainId
+  })
   it('should return true on check with data signed with zero', async function () {
     const messageHash = '0xf7cf90057f86838e5efd677f4741003ab90910e4e2736ff4d7999519d162d1ed'
 
@@ -43,7 +48,6 @@ contract('RSKAddressValidator', function (accounts) {
 
   it('should return FALSE on check with small case address and TRUE on check with checksummed address', async function () {
     const messageHash = '0x4d3e45a3a5908513a10012e30a04fb2b438bab7da2acb93084e2f15a5eb55e8b'
-
     const v = 27
     const r = '90ef8cbc9ce5999887d32f3f5adf5292ada96b9506b51980f219d60271cf300c'
     const s = '3e59fb0088da48b32cb4d83f17af47dd7340cd0dab15ac214b7039b65ee8876d'
@@ -53,6 +57,7 @@ contract('RSKAddressValidator', function (accounts) {
     addressValidator = await TestRSKAddressValidator.new()
     const addr = await addressValidator.getAddress.call(messageHash, signature)
     expect(addr).to.be.not.equal('0xdcc703c0e500b653ca82273b7bfad8045d85a470')
+    console.log('WARN: In testnet or mainnet with EIP1191, the chainID must be added to toChecksumAddress in order to pass')
     expect(addr).to.be.equal(toChecksumAddress('0xdcc703c0e500b653ca82273b7bfad8045d85a470'))
   })
 

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -69,7 +69,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
   beforeEach(async function prepareForHub () {
     env = await getTestingEnvironment()
     chainId = env.chainId
-    gaslessAccount = getGaslessAccount()
+    gaslessAccount = await getGaslessAccount()
 
     const sWalletTemplate: SmartWalletInstance = await SmartWallet.new()
     const factory: ProxyFactoryInstance = await createProxyFactory(sWalletTemplate)
@@ -236,7 +236,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
       await misbehavingPaymaster.deposit({ value: ether('0.1') })
       await misbehavingPaymaster.setOverspendAcceptGas(true)
 
-      const senderNonce = (await forwarderInstance.getNonce()).toString()
+      const senderNonce = (await forwarderInstance.nonce()).toString()
       const relayRequestMisbehaving = cloneRelayRequest(relayRequest)
       relayRequestMisbehaving.relayData.paymaster = misbehavingPaymaster.address
       relayRequestMisbehaving.request.nonce = senderNonce
@@ -320,7 +320,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
       .forEach(([doRevert, len, b]) => {
         it(`should calculate overhead regardless of return value len (${len}) or revert (${doRevert})`, async () => {
           const beforeBalances = getBalances()
-          const senderNonce = (await forwarderInstance.getNonce()).toString()
+          const senderNonce = (await forwarderInstance.nonce()).toString()
           let encodedFunction
           if (len === 0) {
             encodedFunction = recipient.contract.methods.checkNoReturnValues(doRevert).encodeABI()
@@ -375,7 +375,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
             assert.notEqual(resultEvent, null, 'didn\'t get TrasnactionResult where it should.')
           }
 
-          const rskDiff: number = isRsk(env) ? 3135 : 0
+          const rskDiff: number = isRsk(env) ? 3160 : 0
           const gasUsed: number = res.receipt.gasUsed
           const diff = await diffBalances(await beforeBalances)
 
@@ -400,7 +400,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
             it(`should compensate relay with requested fee of ${requestedFee.toString()}% with ${messageLength.toString()} calldata size`, async function () {
               const beforeBalances = await getBalances()
               const pctRelayFee = requestedFee.toString()
-              const senderNonce = (await forwarderInstance.getNonce()).toString()
+              const senderNonce = (await forwarderInstance.nonce()).toString()
               const encodedFunction = recipient.contract.methods.emitMessage('a'.repeat(messageLength)).encodeABI()
               const baseRelayFee = '0'
 

--- a/test/SampleRecipient.test.ts
+++ b/test/SampleRecipient.test.ts
@@ -22,7 +22,7 @@ contract('SampleRecipient', function (accounts) {
   let gaslessAccount: AccountKeypair
 
   before(async function () {
-    gaslessAccount = getGaslessAccount()
+    gaslessAccount = await getGaslessAccount()
     const env = await getTestingEnvironment()
     const chainId = env.chainId
     const sWalletTemplate: SmartWalletInstance = await SmartWallet.new()

--- a/test/StakeManager.test.ts
+++ b/test/StakeManager.test.ts
@@ -85,7 +85,7 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
           value: initialStake,
           from: relayManager
         }),
-        'relayManager cannot stake for itself'
+        'caller is the relayManager'
       )
     })
 

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -5,7 +5,7 @@ import path from 'path'
 
 import { ether } from '@openzeppelin/test-helpers'
 
-import { RelayHubInstance, StakeManagerInstance, ProxyFactoryInstance, IForwarderInstance, SmartWalletInstance } from '../types/truffle-contracts'
+import { RelayHubInstance, StakeManagerInstance, ProxyFactoryInstance, IForwarderInstance, SmartWalletInstance, TestRecipientInstance } from '../types/truffle-contracts'
 import HttpWrapper from '../src/relayclient/HttpWrapper'
 import HttpClient from '../src/relayclient/HttpClient'
 import { configureGSN } from '../src/relayclient/GSNConfigurator'
@@ -17,7 +17,7 @@ import TypedRequestData, { GsnRequestType, getDomainSeparatorHash, ENVELOPING_PA
 import { soliditySha3Raw } from 'web3-utils'
 
 // @ts-ignore
-import { TypedDataUtils } from 'eth-sig-util'
+import { TypedDataUtils, signTypedData_v4 } from 'eth-sig-util'
 import { BN, bufferToHex, toBuffer, toChecksumAddress, privateToAddress } from 'ethereumjs-util'
 import { constants } from '../src/common/Constants'
 
@@ -25,6 +25,8 @@ import { AccountKeypair } from '../src/relayclient/AccountManager'
 
 // @ts-ignore
 import ethWallet from 'ethereumjs-wallet'
+import { Address } from '../src/relayclient/types/Aliases'
+import RelayRequest from '../src/common/EIP712/RelayRequest'
 
 require('source-map-support').install({ errorFormatterForce: true })
 
@@ -263,11 +265,13 @@ export async function createProxyFactory (template: IForwarderInstance, versionH
   return await ProxyFactory.new(template.address, versionHash)
 }
 
-export async function createSmartWallet (ownerEOA: string, factory: ProxyFactoryInstance, privKey: Buffer, chainId: number = 33, logicAddr: string = constants.ZERO_ADDRESS,
+export async function createSmartWallet (ownerEOA: string, factory: ProxyFactoryInstance, privKey: Buffer, chainId: number = -1, logicAddr: string = constants.ZERO_ADDRESS,
   initParams: string = '0x', tokenContract: string = constants.ZERO_ADDRESS, tokenRecipient: string = constants.ZERO_ADDRESS, tokenAmount: string = '0',
   gas: string = '400000'): Promise<SmartWalletInstance> {
   const typeName = `${GsnRequestType.typeName}(${ENVELOPING_PARAMS},${GsnRequestType.typeSuffix}`
   const typeHash = web3.utils.keccak256(typeName)
+  chainId = (chainId < 0 ? (await getTestingEnvironment()).chainId : chainId)
+
   const rReq = {
     request: {
       from: ownerEOA,
@@ -304,7 +308,7 @@ export async function createSmartWallet (ownerEOA: string, factory: ProxyFactory
   const deploySignature = getLocalEip712Signature(createdataToSign, privKey)
   const encoded = TypedDataUtils.encodeData(createdataToSign.primaryType, createdataToSign.message, createdataToSign.types)
   const countParams = ForwardRequestType.length
-  const suffixData = bufferToHex(encoded.slice((1 + countParams) * 32))
+  const suffixData = bufferToHex(encoded.slice((1 + countParams) * 32)) // keccak256 of suffixData
   await factory.relayedUserSmartWalletCreation(rReq.request, getDomainSeparatorHash(factory.address, chainId), typeHash, suffixData, deploySignature)
 
   const swAddress = await factory.getSmartWalletAddress(ownerEOA, constants.ZERO_ADDRESS, logicAddr, soliditySha3Raw({ t: 'bytes', v: initParams }), '0')
@@ -315,12 +319,13 @@ export async function createSmartWallet (ownerEOA: string, factory: ProxyFactory
   return sw
 }
 
-export function getGaslessAccount (): AccountKeypair {
+export async function getGaslessAccount (): Promise<AccountKeypair> {
   const a = ethWallet.generate()
   const gaslessAccount = {
     privateKey: a.privKey,
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    address: toChecksumAddress(bufferToHex(privateToAddress(a.privKey)))
+    address: toChecksumAddress(bufferToHex(privateToAddress(a.privKey)), (await getTestingEnvironment()).chainId).toLowerCase()
+
   }
 
   return gaslessAccount
@@ -330,12 +335,12 @@ export function getGaslessAccount (): AccountKeypair {
 export async function getExistingGaslessAccount (): Promise<AccountKeypair> {
   const gaslessAccount = {
     privateKey: toBuffer('0x082f57b8084286a079aeb9f2d0e17e565ced44a2cb9ce4844e6d4b9d89f3f595'),
-    address: '0x09a1eda29f664ac8f68106f6567276df0c65d859'
+    address: toChecksumAddress('0x09a1eda29f664ac8f68106f6567276df0c65d859', (await getTestingEnvironment()).chainId).toLowerCase()
   }
 
   const balance = new BN(await web3.eth.getBalance(gaslessAccount.address))
   if (!balance.eqn(0)) {
-    const receiverAddress = toChecksumAddress(bufferToHex(privateToAddress(toBuffer(bytes32(1)))))
+    const receiverAddress = toChecksumAddress(bufferToHex(privateToAddress(toBuffer(bytes32(1)))), (await getTestingEnvironment()).chainId).toLowerCase()
 
     await web3.eth.sendTransaction({
       from: gaslessAccount.address,
@@ -365,6 +370,50 @@ export function stripHex (s: string): string {
 
 export function bufferToHexString (b: Buffer): string {
   return '0x' + b.toString('hex')
+}
+
+export async function prepareTransaction (testRecipient: TestRecipientInstance, account: AccountKeypair, relayWorker: Address, paymaster: Address, web3: Web3, nonce: string, swallet: string): Promise<{ relayRequest: RelayRequest, signature: string}> {
+  const paymasterData = '0x'
+  const clientId = '1'
+  const relayRequest: RelayRequest = {
+    request: {
+      to: testRecipient.address,
+      data: testRecipient.contract.methods.emitMessage('hello world').encodeABI(),
+      from: account.address,
+      nonce: nonce,
+      value: '0',
+      gas: '10000',
+      tokenRecipient: constants.ZERO_ADDRESS,
+      tokenContract: constants.ZERO_ADDRESS,
+      tokenAmount: '0',
+      factory: constants.ZERO_ADDRESS, // only set if this is a deploy request
+      recoverer: constants.ZERO_ADDRESS,
+      index: '0'
+    },
+    relayData: {
+      pctRelayFee: '1',
+      baseRelayFee: '1',
+      gasPrice: '1',
+      paymaster,
+      paymasterData,
+      clientId,
+      forwarder: swallet,
+      relayWorker
+    }
+  }
+
+  const dataToSign = new TypedRequestData(
+    (await getTestingEnvironment()).chainId,
+    swallet,
+    relayRequest
+  )
+
+  const signature = signTypedData_v4(account.privateKey, { data: dataToSign })
+
+  return {
+    relayRequest,
+    signature
+  }
 }
 
 /**

--- a/test/Utils.test.ts
+++ b/test/Utils.test.ts
@@ -35,22 +35,24 @@ interface SplittedRelayRequest {
   encodedRelayData: string
 }
 
-const senderAccount: AccountKeypair = getGaslessAccount()
-
 contract('Utils', function (accounts) {
   // This test verifies signing typed data with a local implementation of signTypedData
   describe('#getLocalEip712Signature()', function () {
     // ganache always reports chainId as '1'
+    let senderAccount: AccountKeypair
     let chainId: number
     let forwarder: PrefixedHexString
     let relayRequest: RelayRequest
-    const senderAddress = senderAccount.address
-    const senderPrivateKey = senderAccount.privateKey
+    let senderAddress: string
+    let senderPrivateKey: Buffer
     let testUtil: TestUtilInstance
     let recipient: TestRecipientInstance
 
     let forwarderInstance: SmartWalletInstance
     before(async () => {
+      senderAccount = await getGaslessAccount()
+      senderAddress = senderAccount.address
+      senderPrivateKey = senderAccount.privateKey
       testUtil = await TestUtil.new()
       chainId = (await testUtil.libGetChainID()).toNumber()
       const sWalletTemplate: SmartWalletInstance = await SmartWallet.new()
@@ -155,7 +157,7 @@ contract('Utils', function (accounts) {
       })
       it('should call target', async function () {
         relayRequest.request.data = await recipient.contract.methods.emitMessage('hello').encodeABI()
-        relayRequest.request.nonce = (await forwarderInstance.getNonce()).toString()
+        relayRequest.request.nonce = (await forwarderInstance.nonce()).toString()
 
         const sig = await getLocalEip712Signature(
           new TypedRequestData(

--- a/test/relayclient/AccountManager.test.ts
+++ b/test/relayclient/AccountManager.test.ts
@@ -1,4 +1,4 @@
-import AccountManager from '../../src/relayclient/AccountManager'
+import AccountManager, { AccountKeypair } from '../../src/relayclient/AccountManager'
 import { defaultEnvironment } from '../../src/common/Environments'
 import { HttpProvider } from 'web3-core'
 import RelayRequest from '../../src/common/EIP712/RelayRequest'
@@ -18,7 +18,7 @@ const { expect, assert } = chai.use(chaiAsPromised)
 chai.use(sinonChai)
 
 contract('AccountManager', function (accounts) {
-  const address = '0x982a8CbE734cb8c29A6a7E02a3B0e4512148F6F9'
+  const address: string = '0x982a8CbE734cb8c29A6a7E02a3B0e4512148F6F9'
   const keypair = {
     privateKey: Buffer.from('d353907ab062133759f149a3afcb951f0f746a65a60f351ba05a3ebf26b67f5c', 'hex'),
     address
@@ -28,22 +28,23 @@ contract('AccountManager', function (accounts) {
     jsonStringifyRequest: false
   })
 
-  const account = getGaslessAccount()
-  let shouldThrow = false
+  let shouldThrow: boolean = false
 
-  const accountManager = new AccountManager(web3.currentProvider as HttpProvider, defaultEnvironment.chainId, config,
-    async (signedData: any): Promise<string> => {
-      if (shouldThrow) {
-        throw new Error('Fail of testing')
-      }
-      // @ts-ignore
-      return sigUtil.signTypedData_v4(account.privateKey, { data: signedData })
-    }
-  )
-  // @ts-ignore
-  sinon.spy(accountManager)
   describe('#addAccount()', function () {
-    it('should save the provided keypair internally', function () {
+    it('should save the provided keypair internally', async function () {
+      const account = await getGaslessAccount()
+      const accountManager = new AccountManager(web3.currentProvider as HttpProvider, defaultEnvironment.chainId, config,
+        async (signedData: any): Promise<string> => {
+          if (shouldThrow) {
+            throw new Error('Fail of testing')
+          }
+          // @ts-ignore
+          return sigUtil.signTypedData_v4(account.privateKey, { data: signedData })
+        }
+      )
+      // @ts-ignore
+      sinon.spy(accountManager)
+
       accountManager.addAccount(keypair)
       // @ts-ignore
       assert.equal(accountManager.accounts[0].privateKey.toString(), keypair.privateKey.toString())
@@ -51,19 +52,44 @@ contract('AccountManager', function (accounts) {
       assert.equal(accountManager.accounts[0].address, keypair.address)
     })
 
-    it('should throw if the provided keypair is not valid', function () {
+    it('should throw if the provided keypair is not valid', async function () {
+      const account = await getGaslessAccount()
+      const accountManager = new AccountManager(web3.currentProvider as HttpProvider, defaultEnvironment.chainId, config,
+        async (signedData: any): Promise<string> => {
+          if (shouldThrow) {
+            throw new Error('Fail of testing')
+          }
+          // @ts-ignore
+          return sigUtil.signTypedData_v4(account.privateKey, { data: signedData })
+        }
+      )
+      // @ts-ignore
+      sinon.spy(accountManager)
+
       const keypair = {
         privateKey: Buffer.from('AAAAAAAAAAAAA6a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d', 'hex'),
         address
       }
+
       expect(() => {
         accountManager.addAccount(keypair)
       }).to.throw('invalid keypair')
     })
   })
   describe('#newAccount()', function () {
-    const accountManager = new AccountManager(web3.currentProvider as HttpProvider, defaultEnvironment.chainId, config)
-    it('should create a new keypair, return it and save it internally', function () {
+    it('should create a new keypair, return it and save it internally', async function () {
+      const account = await getGaslessAccount()
+      const accountManager = new AccountManager(web3.currentProvider as HttpProvider, defaultEnvironment.chainId, config,
+        async (signedData: any): Promise<string> => {
+          if (shouldThrow) {
+            throw new Error('Fail of testing')
+          }
+          // @ts-ignore
+          return sigUtil.signTypedData_v4(account.privateKey, { data: signedData })
+        }
+      )
+      // @ts-ignore
+      sinon.spy(accountManager)
       const keypair = accountManager.newAccount()
       // @ts-ignore
       assert.equal(accountManager.accounts[0].privateKey.toString(), keypair.privateKey.toString())
@@ -72,7 +98,10 @@ contract('AccountManager', function (accounts) {
   })
 
   describe('#sign()', function () {
-    accountManager.addAccount(keypair)
+    let account: AccountKeypair
+    let accountManager: AccountManager
+    shouldThrow = false
+
     const relayRequest: RelayRequest = {
       request: {
         to: constants.ZERO_ADDRESS,
@@ -99,7 +128,20 @@ contract('AccountManager', function (accounts) {
         clientId: '1'
       }
     }
-    beforeEach(function () {
+    beforeEach(async function () {
+      account = await getGaslessAccount()
+      accountManager = new AccountManager(web3.currentProvider as HttpProvider, defaultEnvironment.chainId, config,
+        async (signedData: any): Promise<string> => {
+          if (shouldThrow) {
+            throw new Error('Fail of testing')
+          }
+          // @ts-ignore
+          return sigUtil.signTypedData_v4(account.privateKey, { data: signedData })
+        }
+      )
+      // @ts-ignore
+      sinon.spy(accountManager)
+      accountManager.addAccount(keypair)
       sinon.resetHistory()
     })
 

--- a/test/relayserver/NetworkSimulation.test.ts
+++ b/test/relayserver/NetworkSimulation.test.ts
@@ -40,7 +40,7 @@ contract('Network Simulation for Relay Server', function (accounts) {
     })
 
     it('should broadcast multiple transactions at once', async function () {
-      const gaslessAccount: AccountKeypair = getGaslessAccount()
+      const gaslessAccount: AccountKeypair = await getGaslessAccount()
 
       const SmartWallet = artifacts.require('SmartWallet')
       const sWalletTemplate = await SmartWallet.new()

--- a/test/relayserver/ServerTestEnvironment.ts
+++ b/test/relayserver/ServerTestEnvironment.ts
@@ -109,7 +109,7 @@ export class ServerTestEnvironment {
 
     this.encodedFunction = this.recipient.contract.methods.emitMessage('hello world').encodeABI()
 
-    const gaslessAccount = getGaslessAccount()
+    const gaslessAccount = await getGaslessAccount()
     this.gasLess = gaslessAccount.address
 
     const sWalletTemplate = await SmartWallet.new()


### PR DESCRIPTION
General optimizations that do not change any logic.
checksummed addresses are now EIP1191, but for regtest, where this EIP is not activated, it is lowercased (forced)
the relayclient's smartwallet deploy gas estimation now works
