### PR TITLE
New relay hub deployed

### DIFF
--- a/dockers/jsrelay/config/gsn-relay-config.json
+++ b/dockers/jsrelay/config/gsn-relay-config.json
@@ -2,7 +2,7 @@
   "baseRelayFee": 70,
   "pctRelayFee": 0,
   "port": 8090,
-  "relayHubAddress": "0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B",
+  "relayHubAddress": "0x2F48284b8595345b89413e184BF423Da62958230",
   "gasPriceFactor": 1.1,
   "ethereumNodeUrl": "http://host.docker.internal:8545",
   "devMode": false


### PR DESCRIPTION
Modify the docker config in order to point to the new correct RelayHub