### PR TITLE
New test recipient contract

### DIFF
--- a/contracts/test/TestTokenRecipient.sol
+++ b/contracts/test/TestTokenRecipient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier:MIT
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/TestTokenRecipient.sol
+++ b/contracts/test/TestTokenRecipient.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier:MIT
+pragma solidity ^0.6.2;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract TestTokenRecipient is ERC20("Test Recipient Token Contract", "TKNR") {
+    function mint(uint amount, address to) public {
+        _mint(msg.sender, amount);
+        _transfer(msg.sender, to, amount);
+    }
+}

--- a/test/Flows.test.ts
+++ b/test/Flows.test.ts
@@ -11,7 +11,8 @@ import {
   TestPaymasterEverythingAcceptedInstance, TestPaymasterPreconfiguredApprovalInstance,
   TestRecipientInstance,
   SmartWalletInstance,
-  ProxyFactoryInstance
+  ProxyFactoryInstance,
+  TestTokenRecipientInstance
 } from '../types/truffle-contracts'
 import { deployHub, startRelay, stopRelay, getTestingEnvironment, createProxyFactory, createSmartWallet, getExistingGaslessAccount } from './TestUtils'
 import { ChildProcessWithoutNullStreams } from 'child_process'
@@ -20,6 +21,7 @@ import { toBuffer } from 'ethereumjs-util'
 import { AccountKeypair } from '../src/relayclient/AccountManager'
 
 const TestRecipient = artifacts.require('tests/TestRecipient')
+const TestTokenRecipient = artifacts.require('tests/TestTokenRecipient')
 const TestPaymasterEverythingAccepted = artifacts.require('tests/TestPaymasterEverythingAccepted')
 const TestPaymasterPreconfiguredApproval = artifacts.require('tests/TestPaymasterPreconfiguredApproval')
 
@@ -42,6 +44,7 @@ options.forEach(params => {
   contract(params.title + 'Flow', function (accounts) {
     let from: Address
     let sr: TestRecipientInstance
+    let str: TestTokenRecipientInstance
     let paymaster: TestPaymasterEverythingAcceptedInstance
     let rhub: RelayHubInstance
     let sm: StakeManagerInstance
@@ -49,6 +52,7 @@ options.forEach(params => {
     let relayClientConfig: Partial<GSNConfig>
     let fundedAccount: AccountKeypair
     let gaslessAccount: AccountKeypair
+    const tokenReceiverAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
     before(async () => {
       const gasPriceFactor = 1.2
@@ -84,8 +88,13 @@ options.forEach(params => {
       }
 
       sr = await TestRecipient.new()
+      str = await TestTokenRecipient.new()
       paymaster = await TestPaymasterEverythingAccepted.new()
       await paymaster.setRelayHub(rhub.address)
+
+      if (!params.relay) {
+        await str.mint('200', from)
+      }
     })
 
     after(async function () {
@@ -111,13 +120,15 @@ options.forEach(params => {
         // @ts-ignore
         const relayProvider = new RelayProvider(web3.currentProvider, relayClientConfig)
         relayProvider.addAccount(gaslessAccount)
+        await str.mint('200', smartWalletInstance.address)
 
         // web3.setProvider(relayProvider)
 
         // NOTE: in real application its enough to set the provider in web3.
         // however, in Truffle, all contracts are built BEFORE the test have started, and COPIED the web3,
         // so changing the global one is not enough...
-        TestRecipient.web3.setProvider(relayProvider)
+        await TestTokenRecipient.web3.setProvider(relayProvider)
+        await TestRecipient.web3.setProvider(relayProvider)
       })
     }
 
@@ -134,13 +145,27 @@ options.forEach(params => {
       assert.equal('hello', res.logs[0].args.message)
     })
 
+    it(params.title + 'send normal transaction to an ERC20 contract', async () => {
+      console.log('running transfer (should succeed)')
+      let res
+      try {
+        const gas = await str.contract.methods.transfer(tokenReceiverAddress, '5').estimateGas()
+        res = await str.transfer(tokenReceiverAddress, '5', {from: from, gas: 1e6})
+      } catch (e) {
+        console.log('error is ', e.message)
+        throw e
+      }
+      const balance = await str.balanceOf(tokenReceiverAddress)
+      assert.equal(balance.toString(), '5')
+    })
+
     it(params.title + 'send gasless transaction', async () => {
       console.log('gasless=' + gaslessAccount.address)
 
-      console.log('running gasless-emitMessage (should fail for direct, succeed for relayed)')
+      console.log('running gasless-transfer (should fail for direct, succeed for relayed)')
       let ex: Error | undefined
       try {
-        const res = await sr.emitMessage('hello, from gasless', { from: gaslessAccount.address, gas: 1e6 })
+        const res = await str.transfer(tokenReceiverAddress, '5', { from: gaslessAccount.address, gas: 1e6 })
         console.log('res after gasless emit:', res.logs[0].args.message)
       } catch (e) {
         ex = e

--- a/test/GsnTestEnvironment.test.ts
+++ b/test/GsnTestEnvironment.test.ts
@@ -1,11 +1,12 @@
 import { GsnTestEnvironment, TestEnvironment } from '../src/relayclient/GsnTestEnvironment'
 import { HttpProvider } from 'web3-core'
 import { expectEvent } from '@openzeppelin/test-helpers'
-import { TestRecipientInstance, ProxyFactoryInstance } from '../types/truffle-contracts'
+import { TestRecipientInstance, ProxyFactoryInstance, TestTokenRecipientInstance } from '../types/truffle-contracts'
 import { getTestingEnvironment, createSmartWallet, getGaslessAccount } from './TestUtils'
 import { constants } from '../src/common/Constants'
 
 const TestRecipient = artifacts.require('TestRecipient')
+const TestTokenRecipient = artifacts.require('TestTokenRecipient')
 const ProxyFactory = artifacts.require('ProxyFactory')
 
 contract('GsnTestEnvironment', function () {
@@ -61,6 +62,38 @@ contract('GsnTestEnvironment', function () {
       assert.equal(events[0].event, 'SampleRecipientEmitted')
       assert.equal(events[0].returnValues.msgSender.toLocaleLowerCase(), wallet.address.toLocaleLowerCase())
     })
+
+    it('should relay using relayTransaction invoking an ERC20 contract', async () => {
+      const tokenReceiverAddress = '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826'
+      const sender = getGaslessAccount()
+      const proxyFactory: ProxyFactoryInstance = await ProxyFactory.at(testEnvironment.deploymentResult.factoryAddress)
+      const str: TestTokenRecipientInstance = await TestTokenRecipient.new()
+
+      const wallet = await createSmartWallet(sender.address, proxyFactory, sender.privateKey, (await getTestingEnvironment()).chainId)
+      await str.mint('200', wallet.address)
+      testEnvironment.relayProvider.relayClient.accountManager.addAccount(sender)
+
+      const ret = await testEnvironment.relayProvider.relayClient.relayTransaction({
+        from: sender.address,
+        to: str.address,
+        forwarder: wallet.address,
+        paymaster: testEnvironment.deploymentResult.naivePaymasterAddress,
+        paymasterData: '0x',
+        gas: '0x' + 1e6.toString(16),
+        data: str.contract.methods.transfer(tokenReceiverAddress, '5').encodeABI(),
+        tokenRecipient: constants.ZERO_ADDRESS,
+        tokenAmount: '0x00',
+        tokenContract: constants.ZERO_ADDRESS,
+        factory: constants.ZERO_ADDRESS,
+        clientId: '1'
+      })
+
+      assert.deepEqual([...ret.relayingErrors.values(), ...ret.pingErrors.values()], [])
+      const events = await str.contract.getPastEvents()
+      assert.equal(events[0].event, 'Transfer')
+      const balance = await str.balanceOf(tokenReceiverAddress)
+      assert.equal(balance.toString(), '5')
+    })
   })
 
   describe('using RelayProvider', () => {
@@ -93,6 +126,30 @@ contract('GsnTestEnvironment', function () {
       }
       const ret = await sr.emitMessage('hello', txDetails)
       expectEvent(ret, 'SampleRecipientEmitted', { msgSender: wallet.address })
+    })
+
+    it('should send relayed transaction invoking an ERC20 contract through RelayProvider', async () => {
+      const tokenReceiverAddress = '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826'
+      const sender = getGaslessAccount()
+      const proxyFactory: ProxyFactoryInstance = await ProxyFactory.at(testEnvironment.deploymentResult.factoryAddress)
+      const str: TestTokenRecipientInstance = await TestTokenRecipient.new()
+
+      const wallet = await createSmartWallet(sender.address, proxyFactory, sender.privateKey, (await getTestingEnvironment()).chainId)
+      testEnvironment.relayProvider.addAccount(sender)
+      await str.mint('200', wallet.address)
+
+      // @ts-ignore
+      TestTokenRecipient.web3.setProvider(testEnvironment.relayProvider)
+
+      const txDetails = {
+        from: sender.address,
+        paymaster: testEnvironment.deploymentResult.naivePaymasterAddress,
+        forwarder: wallet.address
+      }
+      const ret = await str.transfer(tokenReceiverAddress, '5', txDetails)
+      expectEvent(ret, 'Transfer')
+      const balance = await str.balanceOf(tokenReceiverAddress)
+      assert.equal(balance.toString(), '5')
     })
   })
 })

--- a/test/GsnTestEnvironment.test.ts
+++ b/test/GsnTestEnvironment.test.ts
@@ -65,7 +65,7 @@ contract('GsnTestEnvironment', function () {
 
     it('should relay using relayTransaction invoking an ERC20 contract', async () => {
       const tokenReceiverAddress = '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826'
-      const sender = getGaslessAccount()
+      const sender = await getGaslessAccount()
       const proxyFactory: ProxyFactoryInstance = await ProxyFactory.at(testEnvironment.deploymentResult.factoryAddress)
       const str: TestTokenRecipientInstance = await TestTokenRecipient.new()
 
@@ -130,7 +130,7 @@ contract('GsnTestEnvironment', function () {
 
     it('should send relayed transaction invoking an ERC20 contract through RelayProvider', async () => {
       const tokenReceiverAddress = '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826'
-      const sender = getGaslessAccount()
+      const sender = await getGaslessAccount()
       const proxyFactory: ProxyFactoryInstance = await ProxyFactory.at(testEnvironment.deploymentResult.factoryAddress)
       const str: TestTokenRecipientInstance = await TestTokenRecipient.new()
 

--- a/test/RelayHub.test.ts
+++ b/test/RelayHub.test.ts
@@ -576,7 +576,7 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, sender
         it('relayCall executes the transaction with an ERC20 recipient and increments sender nonce on hub', async function () {
           await testTokenRecipient.mint('200', forwarder)
 
-          const nonceBefore = await forwarderInstance.getNonce()
+          const nonceBefore = await forwarderInstance.nonce()
           const encodedFunction = await testTokenRecipient.contract.methods.transfer(tokenReceiverAddress, '5').encodeABI()
           const relayRequestTokenTransferData = cloneRelayRequest(relayRequest)
           relayRequestTokenTransferData.request.data = encodedFunction
@@ -596,7 +596,7 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, sender
             gas,
             gasPrice
           })
-          const nonceAfter = await forwarderInstance.getNonce()
+          const nonceAfter = await forwarderInstance.nonce()
           assert.equal(nonceBefore.addn(1).toNumber(), nonceAfter.toNumber())
           const balance = await testTokenRecipient.balanceOf(tokenReceiverAddress)
           chai.expect('5').to.be.bignumber.equal(balance)

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -400,7 +400,7 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relayWorker, otherR
 
           const relayCallTxDataSig = await getDataAndSignatureFromHash(relayCallTx.tx, env)
 
-          const rskDifference: number = isRsk(env) ? 105000 : 0
+          const rskDifference: number = isRsk(env) ? 105525 : 0
 
           await expectPenalization(
             async (opts) => await penalizer.penalizeIllegalTransaction(relayCallTxDataSig.data, relayCallTxDataSig.signature, relayHub.address, opts), rskDifference

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -16,9 +16,9 @@ import {
   PenalizerInstance,
   RelayHubInstance, StakeManagerInstance,
   TestPaymasterEverythingAcceptedInstance,
-  TestRecipientInstance,
   SmartWalletInstance,
-  ProxyFactoryInstance
+  ProxyFactoryInstance,
+  TestTokenRecipientInstance
 } from '../types/truffle-contracts'
 
 import { deployHub, getTestingEnvironment, createProxyFactory, createSmartWallet, getGaslessAccount } from './TestUtils'
@@ -30,7 +30,7 @@ import TransactionResponse = Truffle.TransactionResponse
 const RelayHub = artifacts.require('RelayHub')
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
-const TestRecipient = artifacts.require('TestRecipient')
+const TestTokenRecipient = artifacts.require('TestTokenRecipient')
 const TestPaymasterEverythingAccepted = artifacts.require('TestPaymasterEverythingAccepted')
 const SmartWallet = artifacts.require('SmartWallet')
 
@@ -43,7 +43,7 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relayWorker, otherR
   let stakeManager: StakeManagerInstance
   let relayHub: RelayHubInstance
   let penalizer: PenalizerInstance
-  let recipient: TestRecipientInstance
+  let recipient: TestTokenRecipientInstance
   let paymaster: TestPaymasterEverythingAcceptedInstance
   let env: Environment
   let forwarder: string
@@ -61,7 +61,7 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relayWorker, otherR
 
     const gasPrice = new BN('1')
     const gasLimit = new BN('5000000')
-    const txData = recipient.contract.methods.emitMessage('').encodeABI()
+    const txData = recipient.contract.methods.transfer(gaslessAccount.address, '5').encodeABI()
 
     const relayRequest: RelayRequest = {
       request: {
@@ -164,7 +164,8 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relayWorker, otherR
       const forwarderInstance = await createSmartWallet(gaslessAccount.address, factory, gaslessAccount.privateKey, env.chainId)
       forwarder = forwarderInstance.address
 
-      recipient = await TestRecipient.new()
+      recipient = await TestTokenRecipient.new()
+      await recipient.mint('200', forwarder)
 
       paymaster = await TestPaymasterEverythingAccepted.new()
       await stakeManager.stakeForAddress(relayManager, 1000, {
@@ -415,7 +416,7 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relayWorker, otherR
           const gasPrice = new BN('1')
           const gasLimit = new BN('1000000')
           const senderNonce = new BN('0')
-          const txData = recipient.contract.methods.emitMessage('').encodeABI()
+          const txData = recipient.contract.methods.transfer(gaslessAccount.address, '5').encodeABI()
           const relayRequest: RelayRequest = {
             request: {
               to: recipient.address,

--- a/test/Utils.test.ts
+++ b/test/Utils.test.ts
@@ -8,7 +8,7 @@ import { HttpProvider } from 'web3-core'
 import RelayRequest from '../src/common/EIP712/RelayRequest'
 import TypedRequestData, { getDomainSeparatorHash } from '../src/common/EIP712/TypedRequestData'
 import { expectEvent } from '@openzeppelin/test-helpers'
-import { SmartWalletInstance, TestRecipientInstance, TestUtilInstance, ProxyFactoryInstance } from '../types/truffle-contracts'
+import { SmartWalletInstance, TestRecipientInstance, TestUtilInstance, ProxyFactoryInstance, TestTokenRecipientInstance } from '../types/truffle-contracts'
 import { PrefixedHexString } from 'ethereumjs-tx'
 import { bufferToHex } from 'ethereumjs-util'
 import { encodeRevertReason, createProxyFactory, createSmartWallet, getGaslessAccount } from './TestUtils'
@@ -16,7 +16,6 @@ import CommandsLogic from '../src/cli/CommandsLogic'
 import { configureGSN, GSNConfig, resolveConfigurationGSN } from '../src/relayclient/GSNConfigurator'
 import { defaultEnvironment } from '../src/common/Environments'
 import { Web3Provider } from '../src/relayclient/ContractInteractor'
-import ForwardRequest from '../src/common/EIP712/ForwardRequest'
 import { constants } from '../src/common/Constants'
 import { AccountKeypair } from '../src/relayclient/AccountManager'
 import { getLocalEip712Signature } from '../src/common/Utils'
@@ -28,12 +27,10 @@ const { expect, assert } = chai.use(chaiAsPromised)
 
 const TestUtil = artifacts.require('TestUtil')
 const TestRecipient = artifacts.require('TestRecipient')
+const TestTokenRecipient = artifacts.require('TestTokenRecipient')
 const SmartWallet = artifacts.require('SmartWallet')
 
-interface SplittedRelayRequest {
-  request: ForwardRequest
-  encodedRelayData: string
-}
+const tokenReceiverAddress = '0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826'
 
 contract('Utils', function (accounts) {
   // This test verifies signing typed data with a local implementation of signTypedData
@@ -47,6 +44,7 @@ contract('Utils', function (accounts) {
     let senderPrivateKey: Buffer
     let testUtil: TestUtilInstance
     let recipient: TestRecipientInstance
+    let testTokenRecipient: TestTokenRecipientInstance
 
     let forwarderInstance: SmartWalletInstance
     before(async () => {
@@ -60,6 +58,7 @@ contract('Utils', function (accounts) {
       forwarderInstance = await createSmartWallet(senderAddress, factory, senderPrivateKey, chainId)
       forwarder = forwarderInstance.address
       recipient = await TestRecipient.new()
+      testTokenRecipient = await TestTokenRecipient.new()
 
       const senderNonce = '0'
       const target = recipient.address
@@ -171,6 +170,50 @@ contract('Utils', function (accounts) {
         })
         const logs = await recipient.contract.getPastEvents(null, { fromBlock: 1 })
         assert.equal(logs[0].event, 'SampleRecipientEmitted')
+      })
+    })
+
+    describe('#callForwarderVerifyAndCallInvokingTokenContract', () => {
+      it('should return revert result because token payment without balance', async function () {
+        relayRequest.request.to = testTokenRecipient.address
+        relayRequest.request.nonce = (await forwarderInstance.getNonce()).toString()
+        relayRequest.request.data = await testTokenRecipient.contract.methods.transfer(tokenReceiverAddress, '5').encodeABI()
+
+        const sig = await getLocalEip712Signature(
+          new TypedRequestData(
+            chainId,
+            forwarder,
+            relayRequest
+          ), senderPrivateKey)
+        const ret = await testUtil.callForwarderVerifyAndCall(relayRequest, sig)
+        const expectedReturnValue = encodeRevertReason('ERC20: transfer amount exceeds balance')
+        expectEvent(ret, 'Called', {
+          success: false,
+          error: expectedReturnValue
+        })
+        const balance = await testTokenRecipient.balanceOf(tokenReceiverAddress)
+        chai.expect('0').to.be.bignumber.equal(balance)
+      })
+
+      it('should call token contract', async function () {
+        await testTokenRecipient.mint('200', forwarder)
+        relayRequest.request.to = testTokenRecipient.address
+        relayRequest.request.nonce = (await forwarderInstance.getNonce()).toString()
+        relayRequest.request.data = await testTokenRecipient.contract.methods.transfer(tokenReceiverAddress, '5').encodeABI()
+        const sig = await getLocalEip712Signature(
+          new TypedRequestData(
+            chainId,
+            forwarder,
+            relayRequest
+          ), senderPrivateKey)
+        const ret = await testUtil.callForwarderVerifyAndCall(relayRequest, sig)
+        const balance = await testTokenRecipient.balanceOf(tokenReceiverAddress)
+        chai.expect('5').to.be.bignumber.equal(balance)
+        expectEvent(ret, 'Called', {
+          error: null
+        })
+        const logs = await testTokenRecipient.contract.getPastEvents(null, { fromBlock: 1 })
+        assert.equal(logs[0].event, 'Transfer')
       })
     })
   })

--- a/test/relayclient/RelayProvider.test.ts
+++ b/test/relayclient/RelayProvider.test.ts
@@ -26,7 +26,7 @@ import {
 } from '../../types/truffle-contracts'
 import { Address } from '../../src/relayclient/types/Aliases'
 import { isRsk } from '../../src/common/Environments'
-import { deployHub, encodeRevertReason, startRelay, stopRelay, getTestingEnvironment, createProxyFactory, createSmartWallet, getGaslessAccount, prepareTransaction } from '../TestUtils'
+import { deployHub, encodeRevertReason, startRelay, stopRelay, getTestingEnvironment, createProxyFactory, createSmartWallet, getGaslessAccount, prepareTransactionRecipient } from '../TestUtils'
 import BadRelayClient from '../dummies/BadRelayClient'
 
 // @ts-ignore
@@ -458,7 +458,7 @@ contract('RelayProvider', function (accounts) {
       await misbehavingPaymaster.setRelayHub(relayHub.address)
       await misbehavingPaymaster.deposit({ value: web3.utils.toWei('2', 'ether') })
       const nonceToUse = await smartWallet.nonce()
-      const { relayRequest, signature } = await prepareTransaction(testRecipient, gaslessAccount, accounts[0], misbehavingPaymaster.address, web3, nonceToUse.toString(), smartWallet.address)
+      const { relayRequest, signature } = await prepareTransactionRecipient(testRecipient, gaslessAccount, accounts[0], misbehavingPaymaster.address, web3, nonceToUse.toString(), smartWallet.address)
       await misbehavingPaymaster.setReturnInvalidErrorCode(true)
 
       const paymasterRejectedReceiptTruffle = await relayHub.relayCall(10e6, relayRequest, signature, '0x', gas, {

--- a/test/relayserver/NetworkSimulation.test.ts
+++ b/test/relayserver/NetworkSimulation.test.ts
@@ -52,6 +52,7 @@ contract('Network Simulation for Relay Server', function (accounts) {
       assert.equal(provider.mempool.size, 0)
       // cannot use the same sender as it will create same request with same forwarder nonce, etc
       const overrideDetails = { from: gaslessAccount.address, forwarder: smartWallet.address }
+      await env.tokenRecipient.mint('200', smartWallet.address)
       // noinspection ES6MissingAwait - done on purpose
       const promises = [env.relayTransaction(false), env.relayTransaction(false, overrideDetails)]
       const txs = await Promise.all(promises)

--- a/test/relayserver/ServerTestEnvironment.ts
+++ b/test/relayserver/ServerTestEnvironment.ts
@@ -119,6 +119,7 @@ export class ServerTestEnvironment {
 
     const smartWallet: SmartWalletInstance = await createSmartWallet(this.gasLess, factory, gaslessAccount.privateKey, chainId)
     this.forwarder = smartWallet
+    await this.tokenRecipient.mint('200', smartWallet.address)
 
     const shared: Partial<GSNConfig> = {
       logLevel: 5,
@@ -231,8 +232,6 @@ export class ServerTestEnvironment {
     signedTx: PrefixedHexString
     txHash: PrefixedHexString
   }> {
-    const toMint = overrideDetails.forwarder ?? this.forwarder.address
-    await this.tokenRecipient.mint('200', toMint)
     const req = await this.createRelayHttpRequest(overrideDetails)
     const signedTx = await this.relayServer.createRelayTransaction(req)
     const txHash = ethUtils.bufferToHex(ethUtils.keccak256(Buffer.from(removeHexPrefix(signedTx), 'hex')))


### PR DESCRIPTION
In most of the test, the recipient contract was changed by a token recipient contract. The problem with the first of these it's that none of its methods changed the state of the contract. Which is an interesting case to test. So we changed the old "recipient.emitMessage" for "recipient.transfer".

We didn't change the recipient on the test that don't matter the recipient, them test another behaviour.

The only test we couldn't make it work with the new recipient contract is Relay Provider