### PR TITLE
Upgraded axios dependency, upgraded truffle patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/web3-provider-engine": "^14.0.0",
     "abi-decoder": "^2.3.0",
     "async-mutex": "^0.2.4",
-    "axios": "^0.20.0",
+    "axios": "^0.21.1",
     "bn.js": "5.1.2",
     "body-parser": "^1.19.0",
     "chai": "^4.2.0",

--- a/patches/truffle+5.1.53.patch
+++ b/patches/truffle+5.1.53.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/truffle/build/cli.bundled.js b/node_modules/truffle/build/cli.bundled.js
-index 73174bf..6dcb057 100755
+index b0a0b40..d775ba1 100755
 --- a/node_modules/truffle/build/cli.bundled.js
 +++ b/node_modules/truffle/build/cli.bundled.js
 @@ -154237,6 +154237,7 @@ async function invokeCompiler({ compilerInput, options }) {
@@ -10,7 +10,3 @@ index 73174bf..6dcb057 100755
    const outputString = solc.compile(inputString);
    const compilerOutput = JSON.parse(outputString);
  
-diff --git a/node_modules/truffle/test/.npmignore b/node_modules/truffle/test/.gitignore
-similarity index 100%
-rename from node_modules/truffle/test/.npmignore
-rename to node_modules/truffle/test/.gitignore

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,10 +2031,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
-  integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
   dependencies:
     follow-redirects "^1.10.0"
 
@@ -12555,6 +12555,7 @@ websocket@1.0.32, websocket@^1.0.28, websocket@^1.0.31, websocket@^1.0.32:
   dependencies:
     debug "^2.2.0"
     es5-ext "^0.10.50"
+    gulp "^4.0.2"
     nan "^2.14.0"
     typedarray-to-buffer "^3.1.5"
     yaeti "^0.0.6"


### PR DESCRIPTION
Upgraded axios version to 0.21.1 to avoid security vulnerabilities.
Upgraded truffle patch to be applied on version 5.1.53.