### PR TITLE
Fix run-tests.sh

### DIFF
--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -23,9 +23,9 @@ When adding new tests, we should compile them first (with `yarn tsc`) before run
 
 - To run all the tests:
 
-`./run-tests`
+`./run-tests.sh`
 
-Note: The script will start an RSK node in regtest mode and then run all the tests. So it takes some time to run the tests.
+Note: The script will start an RSK node in regtest mode and then run all the tests. So it takes some time to run the tests. You need to have `curl` in order to run it.
 
 - To run a specific test:
 

--- a/rsknode/Dockerfile
+++ b/rsknode/Dockerfile
@@ -35,5 +35,4 @@ ENTRYPOINT ["java", \
     "-Drsk.conf.file=./node.conf", \
     "-Dlogback.configurationFile=./logback.xml", \
     "-Ddatabase.dir=./db", \
-    "-Drpc.providers.web.http.hosts.0=localhost", \
     "-cp", "./rsk.jar", "co.rsk.Start" ]

--- a/rsknode/node.conf
+++ b/rsknode/node.conf
@@ -31,13 +31,13 @@ rpc {
             http: {
                 enabled: true,
                 bind_address = "0.0.0.0",
-                hosts = ["localhost","127.0.0.1"]
+                hosts = ["localhost","127.0.0.1","enveloping-rskj"]
                 port: 4444,
                 }
             ws: {
                 enabled: true,
                 bind_address: "0.0.0.0",
-                hosts = ["localhost","127.0.0.1"]
+                hosts = ["localhost","127.0.0.1","enveloping-rskj"]
                 port: 4445,
             }
         }

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,7 +7,9 @@ run_batch()
 
 	_i=0
 	while [ $_i -lt 30 ]; do
-		nc -z 127.0.0.1 4444 && break
+		curl -Ss -H "Content-type: application/json" \
+		    -d '{"jsonrpc":"2.0","method":"eth_blockNumber","id":"boot-test"}' \
+		    http://127.0.0.1:4444/ 2>/dev/null | grep -q result && break
 		sleep 1
 		_i=$((_i + 1))
 	done


### PR DESCRIPTION
- Detect more reliably if the node is up and responding
- Don't redefine `rpc.providers.web.http.hosts` in `ENTRYPOINT`
- Add `enveloping-rskj` as an allowed host