### PR TITLE
qos/Fix postpack script adding RelayEvents among the files to be removed

### DIFF
--- a/scripts/postpack
+++ b/scripts/postpack
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 #these files were created for packing only (see "prepack")
-for c in RelayProvider RelayClient Configurator TestEnvironment Utils; do
+for c in RelayProvider RelayClient RelayEvents Configurator TestEnvironment Utils; do
   echo del ./$c.ts:
   rm $c.ts
 done


### PR DESCRIPTION
## What

- It adds the RelayEvents among the files to be removed by the `postpack` script

## Why

- The file `RelayEvents.ts` is created by the `prepublish` script

It is a copy of [PR#175](https://github.com/rsksmart/rif-relay/pull/175)