### PR TITLE
PP 271: Fix configurator tests

### DIFF
--- a/test/relayclient/Configurator.test.ts
+++ b/test/relayclient/Configurator.test.ts
@@ -18,7 +18,7 @@ contract('client-configuration', () => {
             it('should fail with no params', async () => {
                 // @ts-ignore
                 await expect(resolveConfiguration()).to.eventually.rejectedWith(
-                    /Cannot read properties/
+                    /Cannot read property/
                 );
             });
 


### PR DESCRIPTION
## What

- Fix configurator tests

## Why
- The expected error message of one of the tests of the configurator is wrong